### PR TITLE
Run terraform init on img creation

### DIFF
--- a/tb-gcp-deploy/pack/init.sh
+++ b/tb-gcp-deploy/pack/init.sh
@@ -82,4 +82,6 @@ mkdir -p /opt/tb
 mv repo /opt/tb/
 
 cd /opt/tb/repo/tb-gcp-tr/landingZone/
+# Download required terraform providers
+terraform init -backend=false
 pwd


### PR DESCRIPTION
This reduces the dependency on Internet access during the Landing Zone's
deployment.