### PR TITLE
Removes license banner to avoid error

### DIFF
--- a/tb-gcp-tr/itop/helm/itop/templates/gateway.yaml
+++ b/tb-gcp-tr/itop/helm/itop/templates/gateway.yaml
@@ -1,17 +1,3 @@
-## Copyright 2019 The Tranquility Base Authors
-## 
-## Licensed under the Apache License, Version 2.0 (the "License");
-## you may not use this file except in compliance with the License.
-## You may obtain a copy of the License at
-## 
-##     http://www.apache.org/licenses/LICENSE-2.0
-## 
-## Unless required by applicable law or agreed to in writing, software
-## distributed under the License is distributed on an "AS IS" BASIS,
-## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-## See the License for the specific language governing permissions and
-## limitations under the License.
-
 {{- if .Values.gateway.enabled -}}
 apiVersion: networking.istio.io/v1alpha3
 kind: Gateway


### PR DESCRIPTION
```
* module.itop.helm_release.itop: 1 error(s) occurred:

* helm_release.itop: rpc error: code = Unknown desc = validation failed: unable to recognize "": no matches for kind "Gateway" in version ""
```