### PR TITLE
Avoids terraform-server running out of memory

### DIFF
--- a/tb-gcp-tr/bootstrap/variables.tf
+++ b/tb-gcp-tr/bootstrap/variables.tf
@@ -77,7 +77,7 @@ variable "terraform_server_name" {
 
 variable "terraform_server_machine_type" {
   type = "string"
-  default = "f1-micro"
+  default = "g1-small"
 }
 
 variable "bootstrap_host_disk_image" {


### PR DESCRIPTION
Example error:
```
module.UI-static-host.null_resource.upload_to_static_host: Still creating... (10s elapsed)
module.UI-static-host.null_resource.upload_to_static_host (local-exec): Traceback (most recent call last):
module.UI-static-host.null_resource.upload_to_static_host (local-exec):   File "/usr/lib/google-cloud-sdk/platform/gsutil/gsutil", line 21, in <module>
module.UI-static-host.null_resource.upload_to_static_host (local-exec):     gsutil.RunMain()
module.UI-static-host.null_resource.upload_to_static_host (local-exec):   File "/usr/lib/google-cloud-sdk/platform/gsutil/gsutil.py", line 124, in RunMain
module.UI-static-host.null_resource.upload_to_static_host (local-exec):     sys.exit(gslib.__main__.main())
module.UI-static-host.null_resource.upload_to_static_host (local-exec):   File "/usr/lib/google-cloud-sdk/platform/gsutil/gslib/__main__.py", line 224, in main
module.UI-static-host.null_resource.upload_to_static_host (local-exec):     gslib.command.InitializeMultiprocessingVariables()
module.UI-static-host.null_resource.upload_to_static_host (local-exec):   File "/usr/lib/google-cloud-sdk/platform/gsutil/gslib/command.py", line 335, in InitializeMultiprocessingVariables
module.UI-static-host.null_resource.upload_to_static_host (local-exec):     manager = multiprocessing.Manager()
module.UI-static-host.null_resource.upload_to_static_host (local-exec):   File "/usr/lib/python2.7/multiprocessing/__init__.py", line 99, in Manager
module.UI-static-host.null_resource.upload_to_static_host (local-exec):     m.start()
module.UI-static-host.null_resource.upload_to_static_host (local-exec):   File "/usr/lib/python2.7/multiprocessing/managers.py", line 524, in start
module.UI-static-host.null_resource.upload_to_static_host (local-exec):     self._process.start()
module.UI-static-host.null_resource.upload_to_static_host (local-exec):   File "/usr/lib/python2.7/multiprocessing/process.py", line 130, in start
module.UI-static-host.null_resource.upload_to_static_host (local-exec):     self._popen = Popen(self)
module.UI-static-host.null_resource.upload_to_static_host (local-exec):   File "/usr/lib/python2.7/multiprocessing/forking.py", line 121, in __init__
module.UI-static-host.null_resource.upload_to_static_host (local-exec):     self.pid = os.fork()
module.UI-static-host.null_resource.upload_to_static_host (local-exec): OSError: [Errno 12] Cannot allocate memory
module.UI-static-host.null_resource.upload_to_static_host (local-exec): Process SyncManager-1:
module.UI-static-host.null_resource.upload_to_static_host (local-exec): Traceback (most recent call last):
module.UI-static-host.null_resource.upload_to_static_host (local-exec):   File "/usr/lib/python2.7/multiprocessing/process.py", line 258, in _bootstrap
module.UI-static-host.null_resource.upload_to_static_host (local-exec):     self.run()
module.UI-static-host.null_resource.upload_to_static_host (local-exec):   File "/usr/lib/python2.7/multiprocessing/process.py", line 114, in run
module.UI-static-host.null_resource.upload_to_static_host (local-exec):     self._target(*self._args, **self._kwargs)
module.UI-static-host.null_resource.upload_to_static_host (local-exec):   File "/usr/lib/python2.7/multiprocessing/managers.py", line 558, in _run_server
module.UI-static-host.null_resource.upload_to_static_host (local-exec):     server.serve_forever()
module.UI-static-host.null_resource.upload_to_static_host (local-exec):   File "/usr/lib/python2.7/multiprocessing/managers.py", line 184, in serve_forever
module.UI-static-host.null_resource.upload_to_static_host (local-exec):     t.start()
module.UI-static-host.null_resource.upload_to_static_host (local-exec):   File "/usr/lib/python2.7/threading.py", line 736, in start
module.UI-static-host.null_resource.upload_to_static_host (local-exec):     _start_new_thread(self.__bootstrap, ())
module.UI-static-host.null_resource.upload_to_static_host (local-exec): error: can't start new thread
```