### PR TITLE
API Endpoint address persistence

### DIFF
--- a/tb-gcp-tr/landingZone/variables.tf
+++ b/tb-gcp-tr/landingZone/variables.tf
@@ -280,7 +280,7 @@ variable "ssp_repository_name" {
 variable "endpoint_file" {
   type        = "string"
   description = "Path to local file that will be created to store istio endpoint. The file will be created in the terraform run or overwritten (if exists). You need to ensure that directory in which it's created exists"
-  default = "/tmp/endpoint-meta.json"
+  default = "/opt/tb/repo/tb-gcp-tr/static-host/config/endpoint-meta.json"
 }
 
 variable "ssp_iam_service_account_roles" {


### PR DESCRIPTION
Moved default directory of UI endpoint-meta.json to /opt/ directory so that the file persists during retries and is committed into source repos