### PR TITLE
Unpins GKE version & fixes incompatibility w/ istio

### DIFF
--- a/tb-gcp-tr/itop/helm/itop/templates/istio-serviceentry.yaml
+++ b/tb-gcp-tr/itop/helm/itop/templates/istio-serviceentry.yaml
@@ -27,24 +27,3 @@ spec:
     protocol: HTTPS
   resolution: DNS
   location: MESH_EXTERNAL
----
-# see https://istio.io/blog/2018/egress-tcp/
-apiVersion: networking.istio.io/v1alpha3
-kind: ServiceEntry
-metadata:
-  name: cloud-sql-instance
-  # namespace: itop
-spec:
-  hosts:
-  # although blog article says that `hosts` field is ignored for TCP service entries,
-  # clients fail to establish connection when `hosts` is omitted,
-  # namely "curl: (56) Recv failure: Connection reset by peer"
-  #
-  # use `gcloud sql instances list` to find out the IP address of your Google Cloud Instance
-  - {{ .Values.istioServiceEntry.cloudSqlInstanceIp }}
-  ports:
-  - name: tcp
-    number: {{ .Values.istioServiceEntry.cloudSqlInstancePort }} # at the moment, Google Cloud SQL always available on port 3307
-    protocol: tcp # enable TCP traffic
-  location: MESH_EXTERNAL
-  resolution: DNS

--- a/tb-gcp-tr/landingZone/input.tfvars
+++ b/tb-gcp-tr/landingZone/input.tfvars
@@ -48,7 +48,7 @@ cluster_ssp_master_authorized_cidrs = [
     display_name = "mgmt-1"
   }
 ]
-cluster_ssp_min_master_version = "1.12.8"
+#cluster_ssp_min_master_version = "latest"
 istio_status = "false"
 ssp_repository_name = "SSP-activator-tf"
 
@@ -65,7 +65,7 @@ cluster_sec_master_authorized_cidrs = [
     display_name = "mgmt-1"
   }
 ]
-cluster_sec_min_master_version = "1.12.8"
+#cluster_sec_min_master_version = "latest"
 vault-lb-name = "sec-vault-lb"
 sec-vault-keyring = "vault"
 location = "EU"
@@ -83,7 +83,7 @@ cluster_opt_master_authorized_cidrs = [
     display_name = "mgmt-1"
   }
 ]
-cluster_opt_min_master_version = "1.12.8"
+#cluster_opt_min_master_version = "latest"
 
 #SSP Deployment
 application_yaml_path = "./deployment.yaml"


### PR DESCRIPTION
6d0f903 (Ricardo Cordeiro, 21 minutes ago)
   Unpins GKE version 1.12.8; latest is now supported

   With the istio fix deployed on the previous commit, the version pinning is
   no longer required. Also, GKE masters with the pinned version are no longer
   available as shown in the following recent error:

   ```
   A 2019-10-01T10:27:58.790002617Z *
   module.gke-ssp.google_container_cluster.gke: 1 error(s) occurred: A
   2019-10-01T10:27:58.790006132Z * google_container_cluster.gke: googleapi:
   Error 400: No valid versions with the prefix "1.12.8" found., badRequest
   ```

95edaea (Ricardo Cordeiro, 23 minutes ago)
   Removes unneeded Cloud SQL Proxy istio ServiceEntry

   This solves the following error seen on GKE clusters post version 1.12.8:

   ``` 
   Error: Error applying plan:

   1 error(s) occurred:

   * module.itop.helm_release.itop: 1 error(s) occurred:

   * helm_release.itop: rpc error: code = Unknown desc = release itop failed:
   admission webhook "pilot.validation.istio.io" denied the request:
   configuration is invalid: domain name "189.85.42" invalid (top level domain
   "42" cannot be all-numeric)