### PR TITLE
Transitions bootstrap deployment to terraform 0.12

### DIFF
--- a/tb-gcp-tr/bootstrap/datasources.tf
+++ b/tb-gcp-tr/bootstrap/datasources.tf
@@ -12,19 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-data "template_file" "startup-script" {
-  template = "${file(var.metadata_startup_script)}"
-  vars = {
-    clusters_master_whitelist_ip = "${google_compute_address.nat_gw_ip.address}"
-    region = "${var.region}"
-    region_zone = "${var.region_zone}"
-    root_id = "${var.folder_id}"
-    root_is_org = "false"
-    billing_account_id = "${var.billing_account_id}"
-    tb_discriminator = "${var.tb_discriminator}"
-    terraform_state_bucket_name = "${google_storage_bucket.terraform-state-bucket-res.name}"
-  }
+data "google_client_config" "this" {
 }
 
-data "google_client_config" "this" {}

--- a/tb-gcp-tr/bootstrap/network.tf
+++ b/tb-gcp-tr/bootstrap/network.tf
@@ -14,57 +14,58 @@
 
 #CREATE-CUSTOM-VPC
 resource "google_compute_network" "bootstrap_network" {
-  name                    = "${var.vpc_name}"
+  name                    = var.vpc_name
   auto_create_subnetworks = "false"
   routing_mode            = "REGIONAL"
-  project                 = "${google_project.bootstrap-res.project_id}"
-  depends_on              = ["google_project_services.bootstrap_project_apis"]
+  project                 = google_project.bootstrap-res.project_id
+  depends_on              = [google_project_services.bootstrap_project_apis]
 }
 
 resource "google_compute_subnetwork" "bootstrap_subnet" {
-  name                     = "${var.subnet_name}"
-  ip_cidr_range            = "${var.subnet_cidr_range}"
-  region                   = "${var.region}"
-  project                  = "${google_project.bootstrap-res.project_id}"
-  network                  = "${google_compute_network.bootstrap_network.name}"
+  name                     = var.subnet_name
+  ip_cidr_range            = var.subnet_cidr_range
+  region                   = var.region
+  project                  = google_project.bootstrap-res.project_id
+  network                  = google_compute_network.bootstrap_network.name
   private_ip_google_access = true
 }
 
 #CREATE-CLOUD-NAT-ROUTER
 resource "google_compute_router" "router" {
-  name    = "${var.router_name}"
-  network = "${google_compute_network.bootstrap_network.name}"
-  project = "${google_project.bootstrap-res.project_id}"
-  region  = "${var.region}"
+  name    = var.router_name
+  network = google_compute_network.bootstrap_network.name
+  project = google_project.bootstrap-res.project_id
+  region  = var.region
 }
 
 resource "google_compute_address" "nat_gw_ip" {
   address_type = "EXTERNAL"
-  name = "${var.router_nat_name}-ip"
-  region = "${var.region}"
-  project = "${google_project.bootstrap-res.project_id}"
-  depends_on = ["google_project_services.bootstrap_project_apis"]
+  name         = "${var.router_nat_name}-ip"
+  region       = var.region
+  project      = google_project.bootstrap-res.project_id
+  depends_on   = [google_project_services.bootstrap_project_apis]
 }
 
 resource "google_compute_router_nat" "nat_gw" {
-  name                               = "${var.router_nat_name}"
-  project                            = "${google_project.bootstrap-res.project_id}"
-  router                             = "${google_compute_router.router.name}"
-  region                             = "${var.region}"
+  name                               = var.router_nat_name
+  project                            = google_project.bootstrap-res.project_id
+  router                             = google_compute_router.router.name
+  region                             = var.region
   nat_ip_allocate_option             = "MANUAL_ONLY"
-  nat_ips                            = ["${google_compute_address.nat_gw_ip.self_link}"]
+  nat_ips                            = [google_compute_address.nat_gw_ip.self_link]
   source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
 }
 
 #CREATE-IAP-FIREWALL-RULES
 resource "google_compute_firewall" "fw_iap_ingress_ssh" {
-  allow = {
-    ports = ["22"]
+  allow {
+    ports    = ["22"]
     protocol = "tcp"
   }
-  description = "Allows known IAP IP ranges to SSH into VMs"
-  name = "allow-iap-ingress-ssh"
-  network = "${google_compute_network.bootstrap_network.name}"
-  project = "${google_project.bootstrap-res.project_id}"
+  description   = "Allows known IAP IP ranges to SSH into VMs"
+  name          = "allow-iap-ingress-ssh"
+  network       = google_compute_network.bootstrap_network.name
+  project       = google_project.bootstrap-res.project_id
   source_ranges = ["35.235.240.0/20"]
 }
+

--- a/tb-gcp-tr/bootstrap/variables.tf
+++ b/tb-gcp-tr/bootstrap/variables.tf
@@ -14,94 +14,101 @@
 
 #PROVIDER
 variable "region" {
-    type = "string"
-    default = "europe-west2"
-    description = "Region name."
+  type        = string
+  default     = "europe-west2"
+  description = "Region name."
 }
 
 variable "region_zone" {
-    type = "string"
-    default = "europe-west2-a"
-    description = "Zone name in the region provided."
+  type        = string
+  default     = "europe-west2-a"
+  description = "Zone name in the region provided."
 }
 
 variable "folder_id" {
-    type = "string"
-    description = "Id for the parent folder where this project will be created."
+  type        = string
+  description = "Id for the parent folder where this project will be created."
 }
 
 variable "billing_account_id" {
-    type = "string"
-    description = "Id of billing account to which bootstrap project will be assigned"
+  type        = string
+  description = "Id of billing account to which bootstrap project will be assigned"
 }
 
 variable "tb_discriminator" {
-  type = "string"
+  type        = string
   description = "sufix added to the names/IDs such elements like Tranquility Base folder, Bootstrap project what allows their coexistence with other sibling TBase instances within the same Organisation/Folder. Example: 'uat', 'dev-am', ''. For the empty value no suffix will be added (thus production ready)."
 }
 
 #CREATE-CUSTOM-VPC
 variable "vpc_name" {
   default = "bootstrap"
-  type = "string"
+  type    = string
 }
 
 variable "subnet_name" {
   default = "bootstrap"
-  type = "string"
+  type    = string
 }
 
 variable "subnet_cidr_range" {
   default = "192.168.0.0/28"
-  type = "string"
+  type    = string
 }
 
 #CREATE-CLOUD-NAT-ROUTER
 variable "router_name" {
-  type = "string"
-  default = "vpc-network-router"
+  type        = string
+  default     = "vpc-network-router"
   description = "Cloud NAT router name"
 }
 
 variable "router_nat_name" {
-  type = "string"
-  default = "vpc-network-nat-gateway"
+  type        = string
+  default     = "vpc-network-nat-gateway"
   description = "Cloud NAT gateway name"
 }
 
 #CREATE-BOOTSTRAP-TERRAFORM-SERVER
 variable "terraform_server_name" {
-  type = "string"
+  type    = string
   default = "terraform-server"
 }
 
 variable "terraform_server_machine_type" {
-  type = "string"
+  type    = string
   default = "g1-small"
 }
 
 variable "bootstrap_host_disk_image" {
-  type = "string"
-  default = "family/tb-tr-debian-9"
+  type        = string
+  default     = "family/tb-tr-debian-9"
   description = "reference to a GCR VM image which will be used for terraform-server instance creation. For more details regarding accepted image references see: https://www.terraform.io/docs/providers/google/r/compute_instance.html#image"
 }
 
 variable "metadata_startup_script" {
-  type = "string"
-  default = "files/bootstrap.sh"
+  type        = string
+  default     = "files/bootstrap.sh"
   description = "Local path to a bootstrap startup script template. Default value is 'files/bootstrap.sh'."
 }
 
 variable "scopes" {
-  type = "list"
-  default = ["https://www.googleapis.com/auth/cloud-platform"]
+  type        = list(string)
+  default     = ["https://www.googleapis.com/auth/cloud-platform"]
   description = "A list of service scopes attached to the bootstrap terraform server. To allow full access to all Cloud APIs, use the cloud-platform scope. For other scopes see here: https://cloud.google.com/sdk/gcloud/reference/alpha/compute/instances/set-scopes#--scopes "
 }
 
 variable "main_iam_service_account_roles" {
-  type = "list"
-  default = ["roles/resourcemanager.folderAdmin", "roles/resourcemanager.projectCreator",
-    "roles/resourcemanager.projectDeleter", "roles/billing.projectManager", "roles/compute.xpnAdmin", "roles/owner",
-    "roles/compute.networkAdmin"]
+  type = list(string)
+  default = [
+    "roles/resourcemanager.folderAdmin",
+    "roles/resourcemanager.projectCreator",
+    "roles/resourcemanager.projectDeleter",
+    "roles/billing.projectManager",
+    "roles/compute.xpnAdmin",
+    "roles/owner",
+    "roles/compute.networkAdmin",
+  ]
   description = "Roles attached to service account"
 }
+

--- a/tb-gcp-tr/bootstrap/versions.tf
+++ b/tb-gcp-tr/bootstrap/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
This requires the use of terraform 0.12 for bootstrap deployments from
now on.