### PR TITLE
Issue #113: Updated the docker image to make the Jenkins LB private

### DIFF
--- a/tb-gcp-activator/files/jenkins-deployment.yaml
+++ b/tb-gcp-activator/files/jenkins-deployment.yaml
@@ -16,6 +16,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: jenkins
+  annotations:
+    cloud.google.com/load-balancer-type: "Internal"
 spec:
   type: LoadBalancer
   ports:

--- a/tb-gcp-activator/main.tf
+++ b/tb-gcp-activator/main.tf
@@ -13,8 +13,7 @@
 # limitations under the License.
 
 provider "google" {
-  version = "~> 1.19"
-  project = "${var.project_id}"
+  version = "~> 2.5"
   region = "${var.region}"
 }
 
@@ -51,7 +50,7 @@ resource "google_project" "activator" {
   folder_id = "${replace(var.activator_folder_id, "folders/" , "")}"
   auto_create_network = false
   billing_account = "${var.billing_account}"
-  labels {
+  labels = {
     review-date = "20190321"
     creation-date = "20190321"
     folder-level-1 = "internal"
@@ -119,7 +118,7 @@ resource "google_project" "workspace" {
   folder_id = "${replace(var.activator_folder_id, "folders/" , "")}"
   auto_create_network = false
   billing_account = "${var.billing_account}"
-  labels {
+  labels = {
     review-date = "20190321"
     creation-date = "20190321"
     folder-level-1 = "internal"

--- a/tb-gcp-activator/variables.tf
+++ b/tb-gcp-activator/variables.tf
@@ -14,6 +14,7 @@
 
 variable "project_id" {
   description = "ID of project to set up the infrastructure on"
+  default = ""
 }
 
 variable "region" {

--- a/tb-gcp-tr/landingZone/deployment.yaml
+++ b/tb-gcp-tr/landingZone/deployment.yaml
@@ -43,7 +43,7 @@ spec:
     spec:
       containers:
       - name: selfservice
-        image: gcr.io/tranquility-base-images/self-service-portal:v31
+        image: gcr.io/tranquility-base-images/self-service-portal:v32
         resources:
           requests:
             cpu: "100m"

--- a/tb-ssp-gcp/Dockerfile
+++ b/tb-ssp-gcp/Dockerfile
@@ -19,12 +19,12 @@ FROM alpine/git AS tbcode
 RUN mkdir -p /opt/tb/repo
 WORKDIR /opt/tb/repo
 
-ARG tb_repo_url=https://github.com/tranquilitybase-io
+ADD tb-common-tr /opt/tb/repo/tb-common-tr/
+ADD tb-gcp-tr /opt/tb/repo/tb-gcp-tr/
+ADD tb-gcp-activator /opt/tb/repo/tb-gcp-activator/
 
-RUN git clone --depth 1 ${tb_repo_url}/tb-common-tr.git
-RUN git clone --depth 1 ${tb_repo_url}/tb-gcp-tr.git
-RUN git clone --depth 1 ${tb_repo_url}/tb-gcp-activator.git
 RUN rm -rf **/.git  rm -rf **/.gitignore **/.idea
+# RUN rm -R tb-gcp
 
 # Build SSP derivelable image
 # --------------------------
@@ -37,9 +37,9 @@ RUN mkdir -p /opt/ssp \
     && mkdir -p /opt/ssp/bash \
     && mkdir -p /root/.ssh
 
-ADD main.py /opt/ssp/
-COPY requirements.txt /opt/ssp/
-COPY modules /opt/ssp/modules/
+ADD tb-ssp-gcp/main.py /opt/ssp/
+COPY tb-ssp-gcp/requirements.txt /opt/ssp/
+COPY tb-ssp-gcp/modules /opt/ssp/modules/
 RUN ls -l /opt/ssp
 
 # START install gcloud
@@ -66,8 +66,8 @@ RUN apt-get install -y p7zip \
 RUN apt-get install -y git
 RUN apt-get install -y dos2unix
 
-COPY git_bash_scripts /opt/ssp/bash/
-COPY tf_create_subnets /opt/ssp/tf_create_subnets/
+COPY tb-ssp-gcp/git_bash_scripts /opt/ssp/bash/
+COPY tb-ssp-gcp/tf_create_subnets /opt/ssp/tf_create_subnets/
 
 RUN chmod +x /opt/ssp/bash/commit_changes.sh && \
     chmod +x /opt/ssp/bash/git_init.sh && \
@@ -77,8 +77,8 @@ RUN dos2unix /opt/ssp/bash/commit_changes.sh && \
     dos2unix /opt/ssp/bash/git_init.sh && \
     dos2unix /opt/ssp/bash/pull_changes.sh
 
-ADD https://releases.hashicorp.com/terraform/0.11.13/terraform_0.11.13_linux_amd64.zip bin/
-RUN unzip -d bin/ bin/terraform_0.11.13_linux_amd64.zip
+ADD https://releases.hashicorp.com/terraform/0.12.17/terraform_0.12.17_linux_amd64.zip bin/
+RUN unzip -d bin/ bin/terraform_0.12.17_linux_amd64.zip
 ENV PATH=$PATH:/
 
 # Enable Terraform logging

--- a/tb-ssp-gcp/Dockerfile
+++ b/tb-ssp-gcp/Dockerfile
@@ -37,7 +37,7 @@ RUN mkdir -p /opt/ssp \
     && mkdir -p /opt/ssp/bash \
     && mkdir -p /root/.ssh
 
-ADD tb-ssp-gcp/main.py /opt/ssp/
+COPY tb-ssp-gcp/main.py /opt/ssp/
 COPY tb-ssp-gcp/requirements.txt /opt/ssp/
 COPY tb-ssp-gcp/modules /opt/ssp/modules/
 RUN ls -l /opt/ssp

--- a/tb-ssp-gcp/Dockerfile
+++ b/tb-ssp-gcp/Dockerfile
@@ -19,9 +19,9 @@ FROM alpine/git AS tbcode
 RUN mkdir -p /opt/tb/repo
 WORKDIR /opt/tb/repo
 
-ADD tb-common-tr /opt/tb/repo/tb-common-tr/
-ADD tb-gcp-tr /opt/tb/repo/tb-gcp-tr/
-ADD tb-gcp-activator /opt/tb/repo/tb-gcp-activator/
+COPY tb-common-tr /opt/tb/repo/tb-common-tr/
+COPY tb-gcp-tr /opt/tb/repo/tb-gcp-tr/
+COPY tb-gcp-activator /opt/tb/repo/tb-gcp-activator/
 
 RUN rm -rf **/.git  rm -rf **/.gitignore **/.idea
 # RUN rm -R tb-gcp

--- a/tb-ssp-gcp/README.md
+++ b/tb-ssp-gcp/README.md
@@ -17,22 +17,15 @@ To run this application we have to create a docker image and place it in a Kuber
 
 ## Build docker image 
 
-Run following commands to create docker image
+Make sure you're in the `tb-gcp` directory. Run following commands to create docker image.
 
 ### Build image
+
 ```bash
 gcloud auth configure-docker
-docker build --no-cache -t <name of your repository>:<version number> .
+docker build --no-cache -f tb-ssp-gcp/Dockerfile -t <name of your repository>:<version number> .
 eg.
-docker build --no-cache -t self-service-portal:v27 .
-```
-
-##### Build arguments
-
-* `tb_repo_url` - URL address to the Tranquility Base repo, the default value is `https://github.com/tranquilitybase-io`. 
-  Example invocation can look like: 
- ```bash
-  docker build -t <name of your repository>:<version number> --build-arg tb_repo_url=https://<USER>@github.com/<YOUR_REPO_EITH_TB> .
+docker build --no-cache -f tb-ssp-gcp/Dockerfile -t self-service-portal:v33 .
 ```
 
 ### Tag image
@@ -40,7 +33,7 @@ docker build --no-cache -t self-service-portal:v27 .
 
 docker tag <name of your repository>:<version number> gcr.io/<project id>/<name of your repository>:<version number>
 eg.
-docker tag self-service-portal:v27 gcr.io/<project_id>/self-service-portal:v27
+docker tag self-service-portal:v33 gcr.io/<project_id>/self-service-portal:v33
 ```
 
 ### Push repository 
@@ -48,5 +41,5 @@ docker tag self-service-portal:v27 gcr.io/<project_id>/self-service-portal:v27
 ```bash
 docker push gcr.io/<project id>/<name of your repository>:<version number>
 eg.
-docker push gcr.io/<project_id>/self-service-portal:v27
+docker push gcr.io/<project_id>/self-service-portal:v33
 ```

--- a/tb-ssp-gcp/modules/subnet_pool_handler.py
+++ b/tb-ssp-gcp/modules/subnet_pool_handler.py
@@ -111,7 +111,7 @@ def replace(file_path, pattern, subst):
         with open(file_path) as old_file:
             for line in old_file:
                 if re.match(pattern, line):
-                    new_file.write(subst + '\n')
+                    new_file.write(subst + "\n")
                 else:
                     new_file.write(line)
     remove(file_path)

--- a/tb-ssp-gcp/modules/subnet_pool_handler.py
+++ b/tb-ssp-gcp/modules/subnet_pool_handler.py
@@ -80,7 +80,7 @@ def update_tf_subnets_input_tfvars(allocated_subnets, input_tfvars_path):
 
 def write_cidr_variable(alocated_subnets, subnet_cidrs, tf_input_path):
     f = open(tf_input_path, "a+")
-    f.write(subnet_cidrs + " = " + str(alocated_subnets).replace("'", "\"") + "\r")
+    f.write(subnet_cidrs + " = " + str(alocated_subnets).replace("'", "\"") + "\n")
     f.close()
 
 
@@ -111,7 +111,7 @@ def replace(file_path, pattern, subst):
         with open(file_path) as old_file:
             for line in old_file:
                 if re.match(pattern, line):
-                    new_file.write(subst + '\r')
+                    new_file.write(subst + '\n')
                 else:
                     new_file.write(line)
     remove(file_path)

--- a/tb-ssp-gcp/tf_create_subnets/main.tf
+++ b/tb-ssp-gcp/tf_create_subnets/main.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 provider "google" {
-  version = "~> 1.19"
+  version = "~> 2.5"
   project = "${var.shared_networking_id}"
   region = "${var.region}"
 }


### PR DESCRIPTION
This PR contains the following changes:

1. Updated the dockerfile to make sure the activator is running the latest terraform version and removed stale repo references. 

2. Changed the google provider version to `2.5` in the activator.

3. Corrected the terraform syntax in some places.