### PR TITLE
Issue #55: Set up CMEK for the terraform state bucket

### DIFF
--- a/tb-gcp-tr/bootstrap/files/bootstrap.sh
+++ b/tb-gcp-tr/bootstrap/files/bootstrap.sh
@@ -39,8 +39,8 @@ key_name = "${key_name}"
 EOF
 
 #Set the default KMS key for the terraform state bucket
-gsutil kms encryption -k projects/${project}/locations/${keyring_location}/keyRings/${keyring_name}/cryptoKeys/${key_name} gs://${terraform_state_bucket_name}
-echo "gsutil kms encryption -k projects/${project}/locations/${keyring_location}/keyRings/${keyring_name}/cryptoKeys/${key_name} gs://${terraform_state_bucket_name}"
+gsutil kms encryption -k projects/"${project}"/locations/"${keyring_location}"/keyRings/"${keyring_name}"/cryptoKeys/"${key_name}" gs://"${terraform_state_bucket_name}"
+echo 'gsutil kms encryption -k projects/"${project}"/locations/"${keyring_location}"/keyRings/"${keyring_name}"/cryptoKeys/"${key_name}" gs://"${terraform_state_bucket_name}"'
 
 terraform init -backend-config="bucket=${terraform_state_bucket_name}" -backend-config="prefix=landingZone"
 

--- a/tb-gcp-tr/bootstrap/files/bootstrap.sh
+++ b/tb-gcp-tr/bootstrap/files/bootstrap.sh
@@ -40,7 +40,6 @@ EOF
 
 #Set the default KMS key for the terraform state bucket
 gsutil kms encryption -k projects/"${project}"/locations/"${keyring_location}"/keyRings/"${keyring_name}"/cryptoKeys/"${key_name}" gs://"${terraform_state_bucket_name}"
-echo 'gsutil kms encryption -k projects/"${project}"/locations/"${keyring_location}"/keyRings/"${keyring_name}"/cryptoKeys/"${key_name}" gs://"${terraform_state_bucket_name}"'
 
 terraform init -backend-config="bucket=${terraform_state_bucket_name}" -backend-config="prefix=landingZone"
 

--- a/tb-gcp-tr/bootstrap/files/bootstrap.sh
+++ b/tb-gcp-tr/bootstrap/files/bootstrap.sh
@@ -32,7 +32,16 @@ root_is_org = "${root_is_org}"
 billing_account_id = "${billing_account_id}"
 tb_discriminator = "${tb_discriminator}"
 terraform_state_bucket_name = "${terraform_state_bucket_name}"
+project = "${project}"
+keyring_location = "${keyring_location}"
+keyring_name = "${keyring_name}"
+key_name = "${key_name}"
 EOF
+
+#Set the default KMS key for the terraform state bucket
+gsutil kms encryption -k projects/${project}/locations/${keyring_location}/keyRings/${keyring_name}/cryptoKeys/${key_name} gs://${terraform_state_bucket_name}
+echo "gsutil kms encryption -k projects/${project}/locations/${keyring_location}/keyRings/${keyring_name}/cryptoKeys/${key_name} gs://${terraform_state_bucket_name}"
+
 terraform init -backend-config="bucket=${terraform_state_bucket_name}" -backend-config="prefix=landingZone"
 
 apply_failures=0

--- a/tb-gcp-tr/bootstrap/input.tfvars
+++ b/tb-gcp-tr/bootstrap/input.tfvars
@@ -21,3 +21,9 @@ tb_discriminator = "dev"
 
 #CREATE-BOOTSTRAP-TERRAFORM-SERVER
 bootstrap_host_disk_image = "projects/<project_id>/global/images/family/tb-tr-debian-9"
+
+#KMS parameters for bucket CMEK encryption
+kms_location = "europe"
+kms_rotation_period = "100000s"
+kms_purpose = "ENCRYPT_DECRYPT"
+kms_algorithm = "CRYPTO_KEY_VERSION_ALGORITHM_UNSPECIFIED"

--- a/tb-gcp-tr/bootstrap/variables.tf
+++ b/tb-gcp-tr/bootstrap/variables.tf
@@ -112,3 +112,19 @@ variable "main_iam_service_account_roles" {
   description = "Roles attached to service account"
 }
 
+variable "kms_location" {
+  type        = string
+  description = "Location of the KMS keyring that will be created to encrypt terraform bucket state"
+}
+variable "kms_rotation_period" {
+  type        = string
+  description = "Rotation period of the KMS crypto key"
+}
+variable "kms_purpose" {
+  type        = string
+  description = "The immutable purpose of this crypto key. A given key can only be used for the operations allowed by its purpose."
+}
+variable "kms_algorithm" {
+  type        = string
+  description = "Indicates what parameters must be used for each cryptographic operation"
+}


### PR DESCRIPTION
Implementation is as follows:
1. Generate KeyRing and CryptoKey in bootstrap project (bootstrap/main.tf)
2. Call "gsutil kms encryption..." from the terraform server startup script (bootstrap/files/bootstrap.sh) in order to set-up the created key as default encrypted key
3. Terraform state is then stored with "Customer-managed key" encryption as opposed to "Google-managed key"

Closes: #55 
