### PR TITLE
Enabled IAM recommender.googleapis.com

### DIFF
--- a/tb-gcp-tr/apis-activation/main.tf
+++ b/tb-gcp-tr/apis-activation/main.tf
@@ -40,12 +40,12 @@ resource "google_project_services" "ssp_project" {
 }
 */
 
-resource "google_project_service" "project" {
+resource "google_project_service" "bastion-iap" {
   project = var.bastion_project_id
   service = "iap.googleapis.com"
   depends_on = ["google_project_services.project"]
 }
-resource "google_project_service" "project" {
+resource "google_project_service" "bastion-recommender" {
   project = var.bastion_project_id
   service = "recommender.googleapis.com"
   depends_on = ["google_project_services.project"]

--- a/tb-gcp-tr/apis-activation/main.tf
+++ b/tb-gcp-tr/apis-activation/main.tf
@@ -70,6 +70,7 @@ resource "google_project_services" "project_shared" {
     "oslogin.googleapis.com",
     "recommender.googleapis.com",
     "serviceusage.googleapis.com",
+    "sourcerepo.googleapis.com",
     "sqladmin.googleapis.com",
     "storage-api.googleapis.com",
   ]

--- a/tb-gcp-tr/apis-activation/main.tf
+++ b/tb-gcp-tr/apis-activation/main.tf
@@ -55,12 +55,14 @@ resource "google_project_services" "project_shared" {
   count   = var.service_projects_number
   project = var.service_project_ids[count.index]
   services = [
+    "appengine.googleapis.com",
     "cloudbilling.googleapis.com",
     "cloudkms.googleapis.com",
     "cloudresourcemanager.googleapis.com",
     "compute.googleapis.com",
     "container.googleapis.com",
     "containerregistry.googleapis.com",
+    "datastore.googleapis.com",
     "iam.googleapis.com",
     "iamcredentials.googleapis.com",
     "logging.googleapis.com",

--- a/tb-gcp-tr/apis-activation/main.tf
+++ b/tb-gcp-tr/apis-activation/main.tf
@@ -15,23 +15,18 @@
 resource "google_project_services" "project" {
   project = var.host_project_id
   services = [
-    "appengine.googleapis.com",
-    "bigquery-json.googleapis.com",
-    "bigquerystorage.googleapis.com",
     "cloudbilling.googleapis.com",
     "cloudkms.googleapis.com",
     "cloudresourcemanager.googleapis.com",
     "compute.googleapis.com",
     "container.googleapis.com",
     "containerregistry.googleapis.com",
-    "datastore.googleapis.com",
     "iam.googleapis.com",
     "iamcredentials.googleapis.com",
     "logging.googleapis.com",
     "monitoring.googleapis.com",
     "oslogin.googleapis.com",
-    "pubsub.googleapis.com",
-    "sourcerepo.googleapis.com",
+    "recommender.googleapis.com",
     "serviceusage.googleapis.com",
     "storage-api.googleapis.com",
   ]
@@ -50,29 +45,29 @@ resource "google_project_service" "project" {
   service = "iap.googleapis.com"
   depends_on = ["google_project_services.project"]
 }
+resource "google_project_service" "project" {
+  project = var.bastion_project_id
+  service = "recommender.googleapis.com"
+  depends_on = ["google_project_services.project"]
+}
 
 resource "google_project_services" "project_shared" {
   count   = var.service_projects_number
   project = var.service_project_ids[count.index]
   services = [
-    "appengine.googleapis.com",
-    "bigquery-json.googleapis.com",
-    "bigquerystorage.googleapis.com",
     "cloudbilling.googleapis.com",
     "cloudkms.googleapis.com",
     "cloudresourcemanager.googleapis.com",
     "compute.googleapis.com",
     "container.googleapis.com",
     "containerregistry.googleapis.com",
-    "datastore.googleapis.com",
     "iam.googleapis.com",
     "iamcredentials.googleapis.com",
     "logging.googleapis.com",
     "monitoring.googleapis.com",
     "oslogin.googleapis.com",
-    "pubsub.googleapis.com",
+    "recommender.googleapis.com",
     "serviceusage.googleapis.com",
-    "sourcerepo.googleapis.com",
     "sqladmin.googleapis.com",
     "storage-api.googleapis.com",
   ]

--- a/tb-marketplace/tb-dep-manager/tranquility-base.jinja
+++ b/tb-marketplace/tb-dep-manager/tranquility-base.jinja
@@ -118,7 +118,7 @@ resources:
     type: vm_instance.py
     properties:
       instanceName: {{ instanceName }}
-      sourceImage: https://www.googleapis.com/compute/v1/projects/tb-marketplace-dev/global/images/tranquility-base-bootstrap-issue-169
+      sourceImage: https://www.googleapis.com/compute/v1/projects/gft-group-public/global/images/tranquility-base-bootstrap-master
       zone: {{ zone }}
       region: {{ region }}
       machineType: {{ machineType }}

--- a/tb-marketplace/tb-dep-manager/tranquility-base.jinja
+++ b/tb-marketplace/tb-dep-manager/tranquility-base.jinja
@@ -118,7 +118,7 @@ resources:
     type: vm_instance.py
     properties:
       instanceName: {{ instanceName }}
-      sourceImage: https://www.googleapis.com/compute/v1/projects/gft-group-public/global/images/tranquility-base-bootstrap-master
+      sourceImage: https://www.googleapis.com/compute/v1/projects/tb-marketplace-dev/global/images/tranquility-base-bootstrap-issue-169
       zone: {{ zone }}
       region: {{ region }}
       machineType: {{ machineType }}


### PR DESCRIPTION
Enabled IAM recommender.googleapis.com for all Shared services projects and disabled also non-used APIs. Closes #169

Evidence:
_root@tb25ed0c-bootstrap-vm:/opt/tb/repo/tb-gcp-tr/landingZone# ./tb-welcome
Time start: 2020-03-20 11:44:46
....
Apply complete! Resources: 2 added, 4 changed, 0 destroyed.

Outputs:

nat-static-ip = 35.246.101.62
sec-cluster_master_auth_0_client_key = 
sec-gke-endpoint = 35.246.101.151
vault-root-token = s.1547G8NbEgZo0dsAYQxXyuJg
.....
Time end: 2020-03-20 12:09:52
root@tb25ed0c-bootstrap-vm:/opt/tb/repo/tb-gcp-tr/landingZone#_ 