### PR TITLE
Decommission SSP appengine deployment and disabling of appengine.googleapis.com from bootstrap

### DIFF
--- a/tb-gcp-tr/landingZone/no-itop/main.tf
+++ b/tb-gcp-tr/landingZone/no-itop/main.tf
@@ -333,14 +333,14 @@ module "SharedServices_ec" {
   dependency_var    = module.SharedServices_configuration_file.id
 }
 
-module "self-service-app" {
-  source = "../../gae-self-service-portal"
-
-  project_id         = module.shared_projects.shared_ec_id
-  source_bucket      = var.ec_ui_source_bucket
-  ec_gke_dependency = null_resource.get_endpoint.id
-  endpoint_file      = var.endpoint_file
-}
+#module "self-service-app" {
+#  source = "../../gae-self-service-portal"
+#
+#  project_id         = module.shared_projects.shared_ec_id
+#  source_bucket      = var.ec_ui_source_bucket
+#  ec_gke_dependency = null_resource.get_endpoint.id
+#  endpoint_file      = var.endpoint_file
+#}
 
 # This is only temporrary piece of code.
 # Creating the endpoint file is a part of istio module in tb-common-tr repository
@@ -368,32 +368,32 @@ resource "null_resource" "get_endpoint" {
   depends_on = [module.SharedServices_ec]
 }
 
-resource "google_storage_bucket_object" "backend-endpoint" {
-  name          = "assets/endpoint-meta.json"
-  bucket        = module.self-service-app.bucket_name
-  source        = var.endpoint_file
-  cache_control = "no-cache, max-age=0"
-
-  # Added depends_on to ensure that this resource isn't created until upload_to_static_host null_resource in module.self-service-app is ready
-  depends_on = [
-    module.self-service-app,
-    null_resource.get_endpoint,
-  ]
-}
+#resource "google_storage_bucket_object" "backend-endpoint" {
+#  name          = "assets/endpoint-meta.json"
+#  bucket        = module.self-service-app.bucket_name
+#  source        = var.endpoint_file
+#  cache_control = "no-cache, max-age=0"
+#
+#  # Added depends_on to ensure that this resource isn't created until upload_to_static_host null_resource in module.self-service-app is ready
+#  depends_on = [
+#    module.self-service-app,
+#    null_resource.get_endpoint,
+#  ]
+#}
 
 // add bucket to store terraform ec activator state
-resource "random_id" "activator_bucket_name" {
-  byte_length = 4
-}
+#resource "random_id" "activator_bucket_name" {
+#  byte_length = 4
+#}
 
-resource "google_storage_bucket_iam_binding" "ec-terraform-state-storage-admin" {
-  bucket = var.terraform_state_bucket_name
-  role   = "roles/storage.admin"
-
-  members = [
-    local.service_account_name,
-  ]
-}
+#resource "google_storage_bucket_iam_binding" "ec-terraform-state-storage-admin" {
+#  bucket = var.terraform_state_bucket_name
+#  role   = "roles/storage.admin"
+#
+#  members = [
+#    local.service_account_name,
+#  ]
+#}
 
 resource "google_sourcerepo_repository" "activator-terraform-code-store" {
   name       = "terraform-code-store"
@@ -413,11 +413,11 @@ resource "google_sourcerepo_repository_iam_binding" "terraform-code-store-admin-
 }
 
 // used only to enable datastore
-resource "google_app_engine_application" "enable-datastore" {
-  project     = module.shared_projects.shared_ec_id
-  location_id = var.region
-  depends_on  = [google_sourcerepo_repository_iam_binding.terraform-code-store-admin-binding]
-}
+#resource "google_app_engine_application" "enable-datastore" {
+#  project     = module.shared_projects.shared_ec_id
+#  location_id = var.region
+#  depends_on  = [google_sourcerepo_repository_iam_binding.terraform-code-store-admin-binding]
+#}
 
 module "bastion-security" {
   source = "../../shared-bastion"

--- a/tb-gcp-tr/landingZone/with-itop/main.tf
+++ b/tb-gcp-tr/landingZone/with-itop/main.tf
@@ -317,6 +317,7 @@ module "k8s-ec_context" {
   source = "../../k8s-context"
 
   cluster_name    = var.cluster_ec_name
+  region = var.region
   cluster_project = module.shared_projects.shared_ec_id
   dependency_var  = module.gke-ec.node_id
 }
@@ -352,14 +353,14 @@ module "SharedServices_ec" {
   dependency_var    = module.SharedServices_configuration_file.id
 }
 
-module "self-service-app" {
-  source = "../../gae-self-service-portal"
-
-  project_id         = module.shared_projects.shared_ec_id
-  source_bucket      = var.ec_ui_source_bucket
-  ec_gke_dependency = null_resource.get_endpoint.id
-  endpoint_file      = var.endpoint_file
-}
+#module "self-service-app" {
+#  source = "../../gae-self-service-portal"
+#
+#  project_id         = module.shared_projects.shared_ec_id
+#  source_bucket      = var.ec_ui_source_bucket
+#  ec_gke_dependency = null_resource.get_endpoint.id
+#  endpoint_file      = var.endpoint_file
+#}
 
 # This is only temporrary piece of code.
 # Creating the endpoint file is a part of istio module in tb-common-tr repository
@@ -387,32 +388,32 @@ resource "null_resource" "get_endpoint" {
   depends_on = [module.SharedServices_ec]
 }
 
-resource "google_storage_bucket_object" "backend-endpoint" {
-  name          = "assets/endpoint-meta.json"
-  bucket        = module.self-service-app.bucket_name
-  source        = var.endpoint_file
-  cache_control = "no-cache, max-age=0"
-
-  # Added depends_on to ensure that this resource isn't created until upload_to_static_host null_resource in module.self-service-app is ready
-  depends_on = [
-    module.self-service-app,
-    null_resource.get_endpoint,
-  ]
-}
+#resource "google_storage_bucket_object" "backend-endpoint" {
+#  name          = "assets/endpoint-meta.json"
+#  bucket        = module.self-service-app.bucket_name
+#  source        = var.endpoint_file
+#  cache_control = "no-cache, max-age=0"
+#
+#  # Added depends_on to ensure that this resource isn't created until upload_to_static_host null_resource in module.self-service-app is ready
+#  depends_on = [
+#    module.self-service-app,
+#    null_resource.get_endpoint,
+#  ]
+#}
 
 // add bucket to store terraform ec activator state
-resource "random_id" "activator_bucket_name" {
-  byte_length = 4
-}
+#resource "random_id" "activator_bucket_name" {
+#  byte_length = 4
+#}
 
-resource "google_storage_bucket_iam_binding" "ec-terraform-state-storage-admin" {
-  bucket = var.terraform_state_bucket_name
-  role   = "roles/storage.admin"
-
-  members = [
-    local.service_account_name,
-  ]
-}
+#resource "google_storage_bucket_iam_binding" "ec-terraform-state-storage-admin" {
+#  bucket = var.terraform_state_bucket_name
+#  role   = "roles/storage.admin"
+#
+#  members = [
+#    local.service_account_name,
+#  ]
+#}
 
 resource "google_sourcerepo_repository" "activator-terraform-code-store" {
   name       = "terraform-code-store"
@@ -432,15 +433,17 @@ resource "google_sourcerepo_repository_iam_binding" "terraform-code-store-admin-
 }
 
 // used only to enable datastore
-resource "google_app_engine_application" "enable-datastore" {
-  project     = module.shared_projects.shared_ec_id
-  location_id = var.region
-  depends_on  = [google_sourcerepo_repository_iam_binding.terraform-code-store-admin-binding]
-}
+#resource "google_app_engine_application" "enable-datastore" {
+#  project     = module.shared_projects.shared_ec_id
+#  location_id = var.region
+#  depends_on  = [google_sourcerepo_repository_iam_binding.terraform-code-store-admin-binding]
+#}
 
 module "bastion-security" {
   source = "../../shared-bastion"
 
+  region = var.region
+  region_zone = var.region_zone
   shared_bastion_id = module.shared_projects.shared_bastion_id
   shared_networking_id = module.shared_projects.shared_networking_id
   nat_static_ip = module.shared-vpc.nat_static_ip

--- a/tb-marketplace/tb-config-creator/README.md
+++ b/tb-marketplace/tb-config-creator/README.md
@@ -24,7 +24,6 @@ This script was created to be executed by future deployers of Tranquility Base f
      - billing.admin
 
  2. Activation of the following APIs:
-   - appengine.googleapis.com
    - cloudbilling.googleapis.com
    - cloudkms.googleapis.com
    - cloudresourcemanager.googleapis.com 
@@ -142,7 +141,6 @@ Example execution
     - at the billing account level
       - billing.admin
   2.Activation of the following API's:
-    - appengine.googleapis.com
     - cloudbilling.googleapis.com
     - cloudkms.googleapis.com
     - cloudresourcemanager.googleapis.com

--- a/tb-marketplace/tb-config-creator/tb-config-creator
+++ b/tb-marketplace/tb-config-creator/tb-config-creator
@@ -104,7 +104,6 @@ echo "    - compute.xpnAdmin"
 echo "  - at the billing account level"
 echo "    - billing.admin"
 echo "2.Activation of the following API's:"
-echo "  - appengine.googleapis.com"
 echo "  - cloudbilling.googleapis.com"
 echo "  - cloudkms.googleapis.com"
 echo "  - cloudresourcemanager.googleapis.com"
@@ -168,7 +167,6 @@ rm billing.yaml billing2.yaml
 
 #Activate essential APIs
 echo "Activating essential APIs..."
-gcloud --project "${PROJECT_ID}" services enable appengine.googleapis.com
 gcloud --project "${PROJECT_ID}" services enable cloudbilling.googleapis.com
 gcloud --project "${PROJECT_ID}" services enable cloudkms.googleapis.com
 gcloud --project "${PROJECT_ID}" services enable cloudresourcemanager.googleapis.com


### PR DESCRIPTION
Decommission the SSP deployment in appengine and removed appengine.googleapis.com from bootstrap enabling

Closes #182 , #192