### PR TITLE
added monitoring api

### DIFF
--- a/tb-gcp-tr/bootstrap/main.tf
+++ b/tb-gcp-tr/bootstrap/main.tf
@@ -53,6 +53,7 @@ resource "google_project_services" "bootstrap_project_apis" {
     "iam.googleapis.com",
     "iamcredentials.googleapis.com",
     "logging.googleapis.com",
+    "monitoring.googleapis.com",
     "oslogin.googleapis.com",
     "pubsub.googleapis.com",
     "serviceusage.googleapis.com",


### PR DESCRIPTION
Added monitoring API to list of services created in bootstrap project, as it is a hidden dependency of the container API and enabled even if not explicitly declared. The current code works, but if monitoring api is not explicitly declared and the TF plan / apply needs to be rerun for any reason, it exhibits strange behavior of removing the monitoring api, which then also implicitly disables the container API.