### PR TITLE
Cloudbuild patch 1

### DIFF
--- a/tb-test/cloudbuild.yaml
+++ b/tb-test/cloudbuild.yaml
@@ -6,7 +6,7 @@ steps:
       - build
       - -force
       - -var
-      - image_name=$_IMAGE_NAME-$BRANCH_NAME-$TAG_NAME
+      - image_name=$_IMAGE_NAME-$BRANCH_NAME
       - -var
       - project_id=$PROJECT_ID
       - -var
@@ -21,13 +21,13 @@ steps:
     name: 'gcr.io/cloud-builders/gcloud'
     waitFor:
       - Package image
-    args: ['compute', 'images', 'update', '$_IMAGE_NAME-$BRANCH_NAME-$TAG_NAME','--update-labels','git_repo=$REPO_NAME,git_commit=$COMMIT_SHA,git_branch=$BRANCH_NAME-$TAG_NAME','--project=$PROJECT_ID']
+    args: ['compute', 'images', 'update', '$_IMAGE_NAME-$BRANCH_NAME','--update-labels','git_repo=$REPO_NAME,git_commit=$COMMIT_SHA,git_branch=$BRANCH_NAME','--project=$PROJECT_ID']
 
   - id: Grant access to image
     name: 'gcr.io/cloud-builders/gcloud'
     waitFor:
       - Label image
-    args: ['compute', 'images', 'add-iam-policy-binding', '$_IMAGE_NAME-$BRANCH_NAME-$TAG_NAME','--member=$_IMAGE_MEMBER','--role=$_IMAGE_ROLE']
+    args: ['compute', 'images', 'add-iam-policy-binding', '$_IMAGE_NAME-$BRANCH_NAME','--member=$_IMAGE_MEMBER','--role=$_IMAGE_ROLE']
 
   # testing starts here
 # create instance from image. instance starting up creates resources required for tranquility base via terraform or GDM in bootstrap.sh
@@ -50,7 +50,7 @@ steps:
 #    name: 'gcr.io/cloud-builders/gcloud'
 #    waitFor:
 #      - Run tests
-#    args: ['compute', 'images', 'export', '--image=$_IMAGE_NAME-$BRANCH_NAME-$TAG_NAME','--destination-uri=gs://$_TB_IMAGE_BUCKET/$_IMAGE_NAME-$BRANCH_NAME-$TAG_NAME-$COMMIT_SHA.tar.gz','--project=$PROJECT_ID']
+#    args: ['compute', 'images', 'export', '--image=$_IMAGE_NAME-$BRANCH_NAME','--destination-uri=gs://$_TB_IMAGE_BUCKET/$_IMAGE_NAME-$BRANCH_NAME-$COMMIT_SHA.tar.gz','--project=$PROJECT_ID']
 
 #  - id: Delete Image from project images
 #    name: 'gcr.io/cloud-builders/gcloud'

--- a/tb-test/cloudbuild_master_release.yaml
+++ b/tb-test/cloudbuild_master_release.yaml
@@ -1,0 +1,70 @@
+steps:
+  - # Build Tranquility Base Image
+    id: Package image
+    name: 'gcr.io/$PROJECT_ID/packer'
+    args:
+      - build
+      - -force
+      - -var
+      - image_name=$_IMAGE_NAME-$BRANCH_NAME$TAG_NAME
+      - -var
+      - project_id=$PROJECT_ID
+      - -var
+      - image_family=$_IMAGE_FAMILY
+      - -var
+      - image_zone=$_IMAGE_ZONE
+      - -var
+      - tb_repos_root_path=.
+      - tb-gcp-deploy/pack/packer-no-itop.json
+
+  - id: Label image
+    name: 'gcr.io/cloud-builders/gcloud'
+    waitFor:
+      - Package image
+    args: ['compute', 'images', 'update', '$_IMAGE_NAME-$BRANCH_NAME$TAG_NAME','--update-labels','git_repo=$REPO_NAME,git_commit=$COMMIT_SHA,git_branch=$BRANCH_NAME$TAG_NAME','--project=$PROJECT_ID']
+
+  - id: Grant access to image
+    name: 'gcr.io/cloud-builders/gcloud'
+    waitFor:
+      - Label image
+    args: ['compute', 'images', 'add-iam-policy-binding', '$_IMAGE_NAME-$BRANCH_NAME$TAG_NAME','--member=$_IMAGE_MEMBER','--role=$_IMAGE_ROLE']
+
+  # testing starts here
+# create instance from image. instance starting up creates resources required for tranquility base via terraform or GDM in bootstrap.sh
+# run inspec tests (or other) after bootstrap.sh finished
+# run 'terraform destroy' or 'gdm delete' to clean up resources
+# delete instance
+  - id: Run tests
+    name: ubuntu
+    waitFor:
+      - Grant access to image
+    entrypoint: bash
+    args:
+    - -c
+    - |
+      chmod +x tb-test/scripts/run-tests.sh
+      ./tb-test/scripts/run-tests.sh
+# testing ends here
+
+#  - id: Copy image to Cloud Storage
+#    name: 'gcr.io/cloud-builders/gcloud'
+#    waitFor:
+#      - Run tests
+#    args: ['compute', 'images', 'export', '--image=$_IMAGE_NAME-$BRANCH_NAME$TAG_NAME','--destination-uri=gs://$_TB_IMAGE_BUCKET/$_IMAGE_NAME-$BRANCH_NAME$TAG_NAME-$COMMIT_SHA.tar.gz','--project=$PROJECT_ID']
+
+#  - id: Delete Image from project images
+#    name: 'gcr.io/cloud-builders/gcloud'
+#    waitFor:
+#      - Copy image to Cloud Storage
+#    args: ['compute', 'images', 'delete', '$_IMAGE_NAME','--project=$PROJECT_ID','--quiet']
+
+substitutions:
+  _TB_IMAGE_BUCKET: tbase-images
+  _IMAGE_NAME: "tranquility-base-bootstrap"
+  _IMAGE_FAMILY: tb-tr-debian-9
+  _IMAGE_ZONE: europe-west2
+  _IMAGE_MEMBER: allAuthenticatedUsers
+  _IMAGE_ROLE: roles/compute.imageUser
+#  _TESTS_DIR: tb-test/scripts
+#  _TEST_INSTANCE_ZONE: europe-west2
+


### PR DESCRIPTION
- reverted cloudbuild.yaml to be used for pushes to github repo.
- tb-test/cloudbuild_master_release.yaml  is to be used for when master is tagged. Will set up a cloud build trigger to use this yaml specifically.

