### PR TITLE
Fixed erroneous pointer to image

### DIFF
--- a/tb-marketplace/tb-dep-manager/tranquility-base.jinja
+++ b/tb-marketplace/tb-dep-manager/tranquility-base.jinja
@@ -118,7 +118,7 @@ resources:
     type: vm_instance.py
     properties:
       instanceName: {{ instanceName }}
-      sourceImage: https://www.googleapis.com/compute/v1/projects/gft-group-public/global/images/tranquility-base-bootstrap-master
+      sourceImage: https://www.googleapis.com/compute/v1/projects/tb-marketplace-dev/global/images/tranquility-base-bootstrap-master
       zone: {{ zone }}
       region: {{ region }}
       machineType: {{ machineType }}


### PR DESCRIPTION
The source image was pointing to the gft-group-public project instead of the tb-marketplace-dev project.