### PR TITLE
Issue-255a this deploys the gcp dac with istio on the shared gke cluster

### DIFF
--- a/tb-gcp-tr/landingZone/eagle_console.yaml
+++ b/tb-gcp-tr/landingZone/eagle_console.yaml
@@ -61,7 +61,6 @@ spec:
       name: https
   selector:
     app: gcpdac
-  clusterIP: None
 ---
 apiVersion: v1
 kind: Service
@@ -133,7 +132,7 @@ spec:
             - name: SQLALCHEMY_TRACK_MODIFICATIONS
               value: "True"
             - name: GCP_DAC_URL
-              value: 'gcpdac:3100'
+              value: 'gcpdac:80'
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -173,7 +172,7 @@ spec:
             - name: CELERY_RESULT_BACKEND
               value: redis://redis:6379
             - name: HOUSTON_SERVICE_URL
-              value: 'houstonservice:3000'
+              value: 'houstonservice:80'
 
         - name: redis
           image: redis:alpine

--- a/tb-gcp-tr/landingZone/eagle_console.yaml
+++ b/tb-gcp-tr/landingZone/eagle_console.yaml
@@ -132,8 +132,8 @@ spec:
               value: "True"
             - name: SQLALCHEMY_TRACK_MODIFICATIONS
               value: "True"
-            - name:  GCP_DAC_URL
-              value: gcp-dac:3100
+            - name: GCP_DAC_URL
+              value: 'gcpdac:3100'
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -172,6 +172,8 @@ spec:
               value: redis://redis:6379
             - name: CELERY_RESULT_BACKEND
               value: redis://redis:6379
+            - name: HOUSTON_SERVICE_URL
+              value: 'houstonservice:3000'
 
         - name: redis
           image: redis:alpine

--- a/tb-gcp-tr/landingZone/eagle_console.yaml
+++ b/tb-gcp-tr/landingZone/eagle_console.yaml
@@ -161,7 +161,7 @@ spec:
     spec:
       containers:
         - name: redis
-          image: redis:alpine
+          image: gcr.io/tranquility-base-images/redis:alpine
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/tb-gcp-tr/landingZone/eagle_console.yaml
+++ b/tb-gcp-tr/landingZone/eagle_console.yaml
@@ -50,6 +50,22 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  name: gcpdac
+spec:
+  ports:
+    - port: 80
+      targetPort: 3100
+      name: http
+    - port: 443
+      targetPort: 3100
+      name: https
+  selector:
+    app: gcpdac
+  clusterIP: None
+---
+apiVersion: v1
+kind: Service
+metadata:
   name: mysql57
 spec:
   ports:
@@ -83,22 +99,6 @@ spec:
           imagePullPolicy: IfNotPresent #Always
           ports:
             - containerPort: 80
-          volumeMounts:
-            - name: config-volume
-              mountPath: /app/ec-config.yaml
-              subPath: ec-config.yaml
-            - name: google-cloud-key
-              mountPath: /var/secrets/google
-          env:
-            - name: GOOGLE_APPLICATION_CREDENTIALS
-              value: /var/secrets/google/ec-service-account-config.json
-      volumes:
-        - name: config-volume
-          configMap:
-            name: ec-config
-        - name: google-cloud-key
-          secret:
-            secretName: ec-service-account
 ---
 
 apiVersion: apps/v1
@@ -125,6 +125,38 @@ spec:
           imagePullPolicy: IfNotPresent #Always
           ports:
             - containerPort: 80
+          env:
+            - name: SQLALCHEMY_DATABASE_URI
+              value: mysql+mysqlconnector://eagle-user:eagle-user-secret-pw@mysql57/eagle_db
+            - name: SQLALCHEMY_ECHO
+              value: "True"
+            - name: SQLALCHEMY_TRACK_MODIFICATIONS
+              value: "True"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gcpdac-v1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gcpdac
+  template:
+    metadata:
+      labels:
+        app: gcpdac
+        version: v1
+    spec:
+      containers:
+        - name: gcpdac
+          image: gcr.io/tranquility-base-images/tb-gcp-dac:landingzone
+          resources:
+            requests:
+              cpu: "100m"
+          imagePullPolicy: IfNotPresent #Always
+          ports:
+            - containerPort: 80
           volumeMounts:
             - name: config-volume
               mountPath: /app/ec-config.yaml
@@ -134,12 +166,37 @@ spec:
           env:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /var/secrets/google/ec-service-account-config.json
-            - name: SQLALCHEMY_DATABASE_URI
-              value: mysql+mysqlconnector://eagle-user:eagle-user-secret-pw@mysql57/eagle_db
-            - name: SQLALCHEMY_ECHO
-              value: "True"
-            - name: SQLALCHEMY_TRACK_MODIFICATIONS
-              value: "True"
+            - name: CELERY_BROKER_URL
+              value: redis://redis:6379
+            - name: CELERY_RESULT_BACKEND
+              value: redis://redis:6379
+
+        - name: redis
+          image: redis:alpine
+
+        - name: gcpdacworker
+          image: gcr.io/tranquility-base-images/tb-gcp-dac:landingzone
+          resources:
+            requests:
+              cpu: "100m"
+          imagePullPolicy: IfNotPresent #Always
+          command: ["celery -E -A celery_worker worker --loglevel=info"]
+          ports:
+            - containerPort: 80
+          volumeMounts:
+            - name: config-volume
+              mountPath: /app/ec-config.yaml
+              subPath: ec-config.yaml
+            - name: google-cloud-key
+              mountPath: /credentials.json
+          env:
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: /var/secrets/google/ec-service-account-config.json
+            - name: CELERY_BROKER_URL
+              value: redis://redis:6379
+            - name: CELERY_RESULT_BACKEND
+              value: redis://redis:6379
+
       volumes:
         - name: config-volume
           configMap:

--- a/tb-gcp-tr/landingZone/eagle_console.yaml
+++ b/tb-gcp-tr/landingZone/eagle_console.yaml
@@ -296,6 +296,37 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
+  name: gcpdacservice
+spec:
+  hosts:
+    - "*"
+  gateways:
+    - mygateway
+  http:
+    - match:
+        - uri:
+            prefix: /api
+      route:
+        - destination:
+            host: gcpdacservice
+            port:
+              number: 80
+      corsPolicy:
+        allowOrigin:
+          - "*"
+        allowMethods:
+          - POST
+          - GET
+          - OPTIONS
+          - PUT
+          - PATCH
+          - DELETE
+        allowHeaders:
+          - "*"
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
   name: eagleconsole
 spec:
   hosts:
@@ -331,6 +362,18 @@ metadata:
     cloud.google.com/load-balancer-type: "Internal"
 spec:
   host: houstonservice
+  trafficPolicy:
+    loadBalancer:
+      simple: LEAST_CONN
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: gcpdacservice
+  annotations:
+    cloud.google.com/load-balancer-type: "Internal"
+spec:
+  host: gcpdacservice
   trafficPolicy:
     loadBalancer:
       simple: LEAST_CONN

--- a/tb-gcp-tr/landingZone/eagle_console.yaml
+++ b/tb-gcp-tr/landingZone/eagle_console.yaml
@@ -72,7 +72,17 @@ spec:
       targetPort: 3306
   selector:
     app: mysql57
-  clusterIP: None
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+spec:
+  ports:
+    - port: 6379
+      targetPort: 6379
+  selector:
+    app: redis
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -137,6 +147,25 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  name: redis-v1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+        version: v1
+    spec:
+      containers:
+        - name: redis
+          image: redis:alpine
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
   name: gcpdac-v1
 spec:
   replicas: 1
@@ -174,9 +203,6 @@ spec:
             - name: HOUSTON_SERVICE_URL
               value: 'houstonservice:80'
 
-        - name: redis
-          image: redis:alpine
-
         - name: gcpdacworker
           image: gcr.io/tranquility-base-images/tb-gcp-dac:landingzone
           resources:
@@ -199,6 +225,8 @@ spec:
               value: redis://redis:6379
             - name: CELERY_RESULT_BACKEND
               value: redis://redis:6379
+            - name: HOUSTON_SERVICE_URL
+              value: 'houstonservice:80'
 
       volumes:
         - name: config-volume
@@ -295,7 +323,7 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
-  name: gcpdacservice
+  name: gcpdac
 spec:
   hosts:
     - "*"
@@ -307,7 +335,7 @@ spec:
             prefix: /api
       route:
         - destination:
-            host: gcpdacservice
+            host: gcpdac
             port:
               number: 80
       corsPolicy:
@@ -341,6 +369,23 @@ spec:
 
 ---
 apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: redis
+spec:
+  hosts:
+    - "*"
+  gateways:
+    - mygateway
+  http:
+    - route:
+        - destination:
+            host: redis
+            port:
+              number: 6379
+
+---
+apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
   name: eagleconsole
@@ -368,11 +413,23 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
-  name: gcpdacservice
+  name: gcpdac
   annotations:
     cloud.google.com/load-balancer-type: "Internal"
 spec:
-  host: gcpdacservice
+  host: gcpdac
+  trafficPolicy:
+    loadBalancer:
+      simple: LEAST_CONN
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: redis
+  annotations:
+    cloud.google.com/load-balancer-type: "Internal"
+spec:
+  host: redis
   trafficPolicy:
     loadBalancer:
       simple: LEAST_CONN

--- a/tb-gcp-tr/landingZone/eagle_console.yaml
+++ b/tb-gcp-tr/landingZone/eagle_console.yaml
@@ -124,7 +124,7 @@ spec:
               cpu: "100m"
           imagePullPolicy: IfNotPresent #Always
           ports:
-            - containerPort: 80
+            - containerPort: 3000
           env:
             - name: SQLALCHEMY_DATABASE_URI
               value: mysql+mysqlconnector://eagle-user:eagle-user-secret-pw@mysql57/eagle_db
@@ -132,6 +132,8 @@ spec:
               value: "True"
             - name: SQLALCHEMY_TRACK_MODIFICATIONS
               value: "True"
+            - name:  GCP_DAC_URL
+              value: gcp-dac:3100
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -156,7 +158,7 @@ spec:
               cpu: "100m"
           imagePullPolicy: IfNotPresent #Always
           ports:
-            - containerPort: 80
+            - containerPort: 3100
           volumeMounts:
             - name: config-volume
               mountPath: /app/ec-config.yaml
@@ -180,7 +182,7 @@ spec:
             requests:
               cpu: "100m"
           imagePullPolicy: IfNotPresent #Always
-          command: ["celery -E -A celery_worker worker --loglevel=info"]
+          command: ['celery', '-E', '-A', 'celery_worker', 'worker', '--loglevel=info']
           ports:
             - containerPort: 80
           volumeMounts:
@@ -188,7 +190,7 @@ spec:
               mountPath: /app/ec-config.yaml
               subPath: ec-config.yaml
             - name: google-cloud-key
-              mountPath: /credentials.json
+              mountPath: /var/secrets/google
           env:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /var/secrets/google/ec-service-account-config.json

--- a/tb-gcp-tr/landingZone/no-itop/ec-configuration-file.tf
+++ b/tb-gcp-tr/landingZone/no-itop/ec-configuration-file.tf
@@ -36,6 +36,8 @@ data:
     shared_network_name: ${var.shared_vpc_name}
     shared_networking_id: ${module.shared_projects.shared_networking_id}
     activator_terraform_code_store: ${google_sourcerepo_repository.activator-terraform-code-store.name}
+    tb_discriminator: ${var.tb_discriminator}
+    jenkins_url: PLACEHOLDER
 FILE
 
 }


### PR DESCRIPTION
## PR Type  
In change deploys the dac services onto the shared gke cluster 
  
Please check the boxes that applies to this PR.  
- [ ] Bugfix  
- [*] Feature  
- [ ] Code style update (formatting, local variables)  
- [ ] Refactoring (no functional changes, no api changes)  
- [ ] Build related changes  
- [ ] CI related changes  
- [ ] Documentation content changes  
- [ ] TranquilityBase application / infrastructure changes  
- [ ] Other... Please describe:  

## Purpose 
This ensures you have all the shared service portal apps (eagle console, houston service and dac) running on the gke cluster

[root@tb-kube-proxy-8cbj ~]# kubectl get pods
NAME                                 READY   STATUS    RESTARTS   AGE
eagleconsole-v1-565bb8c6c-5b5fs      2/2     Running   0          116m
gcpdac-v1-6864f588b5-lld42           4/4     Running   2          114m
houstonservice-v1-6d85fb7d85-dt6gl   2/2     Running   0          116m
mysql57-5dfcbc76c6-mczsp             2/2     Running   0          116m

Tested accessing the eagle console and also selecting an activator deploy and seeing the call to the houston service (tested this with the help of Fabio) what didn't work is the houston and DAC speaking to each other which I think @sunderhill-gft and @karwootang-gft can have a look and see if the config needs modification. If there are config changes it would be to eagle_console.yaml file and it should be relatively small is my initially understanding at this point.
 
## Reviewers  
@sunderhill-gft , @Salles-FA , @wills-gft , @scottholmangft ,
  
  ## Checklist  
 - [ ] This PR is linked to one or more issues.  
 - [*] This PR has been tested (attach evidence if possible) - Details above
 - [ ] This PR has passed style guidelines.  
