### PR TITLE
Fixes #363 Enables PGA on shared-network-snet

### DIFF
--- a/tb-gcp-tr/shared-vpc/main.tf
+++ b/tb-gcp-tr/shared-vpc/main.tf
@@ -36,6 +36,7 @@ resource "google_compute_subnetwork" "standard" {
   name          = var.standard_network_subnets[count.index]["name"]
   ip_cidr_range = var.standard_network_subnets[count.index]["cidr"]
   region        = var.region
+  private_ip_google_access = true
   project       = var.host_project_id
   network       = google_compute_network.shared_network.name
 


### PR DESCRIPTION
## PR Type  
What kind of change does this PR introduce?  

Useful if Cloud NAT is removed on fully private environments which is useful if Cloud NAT is removed on fully private environments.

Please check the boxes that applies to this PR.  
  
- [ ] Bugfix  
- [X] Feature  
- [ ] Code style update (formatting, local variables)  
- [ ] Refactoring (no functional changes, no api changes)  
- [ ] Build related changes  
- [ ] CI related changes  
- [ ] Documentation content changes  
- [ ] TranquilityBase application / infrastructure changes  
- [ ] Other... Please describe:  


## Purpose 

The purpose has been fully described on issue #363. Here's a small quote of the whole issue which summarizes the purpose:
> Even though Cloud NAT is deployed by default and it implicitly enables Private Google Access (PGA), this functionality should be enabled explicitly for the shared-network-snet subnetwork deployed by the shared-vpc module.

further arguments are presented on the issue #363. 
  
## Reviewers  
 - **RDHA-GFT** please review this part.  
 - **scottholmangft** please review this part.  
  
  ## Checklist  
 - [X] This PR is linked to one or more issues.  
 - [X] This PR has been tested (attach evidence if possible).  
 - [X] This PR has passed style guidelines.  

This commit was successfully deployed on a customer environment. 