### PR TITLE
Fixes #364 bastion CIDR variable is no longer ignored

### DIFF
--- a/tb-gcp-tr/shared-vpc/main.tf
+++ b/tb-gcp-tr/shared-vpc/main.tf
@@ -81,7 +81,7 @@ resource "google_compute_subnetwork" "gke" {
 
 resource "google_compute_subnetwork" "shared-bastion-subnetwork" {
   name                     = "bastion-subnetwork"
-  ip_cidr_range            = "10.0.6.0/24"
+  ip_cidr_range            = var.bastion_subnet_cidr
   region                   = var.region
   private_ip_google_access = true
   project                  = var.host_project_id


### PR DESCRIPTION
## PR Type  
*What kind of change does this PR introduce?*

Stops the `shared-vpc` terraform module from ignoring the `bastion_subnet_cidr` variable.

Please check the boxes that applies to this PR.  
  
- [X] Bugfix  
- [ ] Feature  
- [ ] Code style update (formatting, local variables)  
- [ ] Refactoring (no functional changes, no api changes)  
- [ ] Build related changes  
- [ ] CI related changes  
- [ ] Documentation content changes  
- [ ] TranquilityBase application / infrastructure changes  
- [ ] Other... Please describe:  

## Purpose 

Allow for the `bastion-subnetwork` primary CIDR range to be changed before deployment.

A more thorough discussion on this has been provided on issue #364's opening comment.

## Reviewers  
 - **RDHA-GFT** please review this part.  
 - *scottholmangft** please review this part.  
  
  ## Checklist  
 - [X] This PR is linked to one or more issues.  
 - [X] This PR has been tested (attach evidence if possible).  
 - [X] This PR has passed style guidelines.

This fix has been successfully tested while deploying a customer environment.