### PR TITLE
Fixes #365 tb-config-creator help typo fix

### DIFF
--- a/tb-marketplace/tb-config-creator/tb-config-creator
+++ b/tb-marketplace/tb-config-creator/tb-config-creator
@@ -26,7 +26,7 @@ function print_help {
   echo "  Either parent-folder-id or organization-id is REQUIRED"
   echo "Example:"
   echo "  $ ./tb-config-creator -f 705953663545 -b F9C122-73127B-50AE5B"
-  echo "  $ ./tb-config-creator -0 123953123545 -b F9C122-73127B-50AE5B"
+  echo "  $ ./tb-config-creator -o 123953123545 -b F9C122-73127B-50AE5B"
 
 }
 


### PR DESCRIPTION
## PR Type  
*What kind of change does this PR introduce?*

Fixes a typo on a help message output.
  
Please check the boxes that applies to this PR.  
  
- [X] Bugfix  
- [ ] Feature  
- [ ] Code style update (formatting, local variables)  
- [ ] Refactoring (no functional changes, no api changes)  
- [ ] Build related changes  
- [ ] CI related changes  
- [ ] Documentation content changes  
- [ ] TranquilityBase application / infrastructure changes  
- [ ] Other... Please describe:  


## Purpose

Fixes `tb-marketplace/tb-config-creator/tb-config-creator`'s script's usage output from:
```
./tb-config-creator -0 123953123545 -b F9C122-73127B-50AE5B
```
to the correct form:
```
./tb-config-creator -o 123953123545 -b F9C122-73127B-50AE5B
```

## Reviewers  
 - **RDHA-GFT** please review this part.  
 - **scottholmangft** please review this part.  
  
  ## Checklist  
 - [X] This PR is linked to one or more issues.  
 - [X] This PR has been tested (attach evidence if possible).  
 - [X] This PR has passed style guidelines.

This fix has been tested during the deployment into a customer environment.