### PR TITLE
Issue 279a - Deploy Jenkins onto the shared gke cluster as part of the landingzone

### DIFF
--- a/tb-gcp-deploy/pack/packer-no-itop.json
+++ b/tb-gcp-deploy/pack/packer-no-itop.json
@@ -112,6 +112,11 @@
     },
     {
       "type": "file",
+      "source": "{{user `tb_repos_root_path`}}/tb-gcp-tr/shared-dac",
+      "destination": "tb-gcp-tr/"
+    },
+    {
+      "type": "file",
       "source": "{{user `tb_repos_root_path`}}/tb-gcp-tr/.gitignore",
       "destination": "tb-gcp-tr/"
     },

--- a/tb-gcp-tr/landingZone/no-itop/input.tfvars
+++ b/tb-gcp-tr/landingZone/no-itop/input.tfvars
@@ -120,3 +120,7 @@ ec_iam_service_account_roles = [
   "roles/datastore.owner",
   "roles/browser",
 "roles/resourcemanager.projectIamAdmin"]
+
+#DAC Services
+sharedservice_namespace_yaml_path = "/opt/tb/repo/tb-gcp-tr/shared-dac/namespaces.yaml"
+sharedservice_jenkinsmaster_yaml_path = "/opt/tb/repo/tb-gcp-tr/shared-dac/jenkins-master.yaml"

--- a/tb-gcp-tr/landingZone/no-itop/main.tf
+++ b/tb-gcp-tr/landingZone/no-itop/main.tf
@@ -171,9 +171,27 @@ module "k8s-ec_context" {
   dependency_var  = module.gke-ec.node_id
 }
 
+## Creating the ssp and cicd namespaces in the shared services cluster ## depends on the k8-ec_content module 
+module "SharedServices_namespace_creation" {
+  source = "../../../tb-common-tr/start_service"
+
+  k8s_template_file = var.sharedservice_namespace_yaml_path
+  cluster_context   = module.k8s-ec_context.context_name
+  dependency_var    = module.k8s-ec_context.k8s-context_id
+}
+
+## Creating the Jenkins service ## depends on the shared namespace module
+module "SharedServices_jenkinsmaster_creation" {
+  source = "../../../tb-common-tr/start_service"
+
+  k8s_template_file = var.sharedservice_jenkinsmaster_yaml_path
+  cluster_context   = module.k8s-ec_context.context_name
+  dependency_var    = module.SharedServices_namespace_creation.id
+}
+
 resource "null_resource" "kubernetes_service_account_key_secret" {
   triggers = {
-    content = module.k8s-ec_context.k8s-context_id
+    content = module.SharedServices_namespace_creation.id
   }
 
   provisioner "local-exec" {

--- a/tb-gcp-tr/landingZone/no-itop/variables.tf
+++ b/tb-gcp-tr/landingZone/no-itop/variables.tf
@@ -306,3 +306,16 @@ variable "private_dns_domain_name" {
   default     = ""
   description = "Domain name for private DNS in the shared vpc network"
 }
+## DAC Services ##########
+# Namespace creations
+variable "sharedservice_namespace_yaml_path" {
+  description = "Path to the yaml file to create namespaces on the shared gke-ec cluster"
+  type        = string
+}
+
+# Jenkins install 
+variable "sharedservice_jenkinsmaster_yaml_path" {
+  description = "Path to the yaml file to deploy Jenkins on the shared gke-ec cluster"
+  type        = string
+}
+

--- a/tb-gcp-tr/shared-dac/jenkins-master.yaml
+++ b/tb-gcp-tr/shared-dac/jenkins-master.yaml
@@ -1,0 +1,154 @@
+### StorageClass ###
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: gold
+provisioner: kubernetes.io/gce-pd
+parameters:
+  type: pd-ssd
+---
+### Persistent volume claim ###
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: jenkins-master-pv-claim 
+  namespace: cicd
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 50Gi
+    storageClassName: gold
+---
+### Jenkins Service ###
+apiVersion: v1
+kind: Service
+metadata:
+  name: jenkins-master-svc
+  namespace: cicd
+  annotations:
+    cloud.google.com/load-balancer-type: "Internal"
+  labels:
+    app: jenkins-master
+spec:
+  type: LoadBalancer
+  ports:
+  - port: 80
+    targetPort: 8080
+    protocol: TCP
+    name: http
+  - port: 50000
+    targetPort: 50000
+    protocol: TCP
+    name: slave
+  selector:
+    app: jenkins-master
+---
+### Jenkins Deployment ###
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app: jenkins-master
+  name: jenkins-master
+  namespace: cicd
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: jenkins-master
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: jenkins-master
+    spec:
+      imagePullSecrets:
+        - name: "docker-hub"
+      spec:
+      containers:
+       - name: jenkins-master
+         image: gcr.io/tranquility-base-images/tb-jenkins_latest:landingzone
+         securityContext:
+            privileged: true
+            runAsUser: 0
+         imagePullPolicy: "Always"
+         volumeMounts:
+          - mountPath: /var
+            name: jenkins-home
+            subPath: jenkins_home
+          - name: docker-sock-volume
+            mountPath: /var/run/docker.sock
+         resources:
+           requests:
+             memory: "1024Mi"
+             cpu: "1"
+           limits: 
+             memory: "4096Mi"
+             cpu: "2"
+         ports:
+           - name: http-port
+             containerPort: 8080
+           - name: jnlp-port
+             containerPort: 50000
+      volumes:
+       - name: jenkins-home
+         persistentVolumeClaim:
+          claimName: jenkins-master-pv-claim
+       - name: docker-sock-volume
+         hostPath:
+           path: /var/run/docker.sock
+           type: File
+status: {}
+---
+### Private-ingressgateway for Jenkins ###
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: jenkins-gateway
+  namespace: cicd
+spec:
+  selector:
+    istio: private-ingressgateway # use istio default controller
+  servers:
+    - port:
+        number: 8080
+        name: http
+        protocol: HTTP
+      hosts:
+        - "*"
+---
+### Jenkins Virtual Service ###
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: jenkinsservice
+  namespace: cicd
+spec:
+  hosts:
+    - "*"
+  gateways:
+    - jenkins-gateway
+  http:
+    - route:
+        - destination:
+            host: jenkins-master
+            port:
+              number: 8080
+      corsPolicy:
+        allowOrigin:
+          - "*"
+        allowMethods:
+          - POST
+          - GET
+          - OPTIONS
+          - PUT
+          - PATCH
+          - DELETE
+        allowHeaders:
+          - "*"
+---
+

--- a/tb-gcp-tr/shared-dac/jenkins-master.yaml
+++ b/tb-gcp-tr/shared-dac/jenkins-master.yaml
@@ -19,7 +19,7 @@ spec:
   resources:
     requests:
       storage: 50Gi
-    storageClassName: gold
+  storageClassName: gold
 ---
 ### Jenkins Service ###
 apiVersion: v1

--- a/tb-gcp-tr/shared-dac/namespaces.yaml
+++ b/tb-gcp-tr/shared-dac/namespaces.yaml
@@ -1,0 +1,30 @@
+# Copyright 2019 The Tranquility Base Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+### Namespace creation file for the shared gke cluster
+
+### Namespace for the eagle console and related services
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ssp
+  labels:
+    name: ssp
+---
+### Namespace for the devops related tools
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cicd
+  labels:
+    name: cicd


### PR DESCRIPTION
## PR Type  
What kind of change does this PR introduce?  
deploys jenkins onto the shared gke cluster on a separate namespace called cicd
Also made provision to create namespaces controlled by a separate yaml file source from the shared-dac folder in tb-gcp-tr
  
Please check the boxes that applies to this PR.  
  
- [ ] Bugfix  
- [*] Feature  
- [ ] Code style update (formatting, local variables)  
- [ ] Refactoring (no functional changes, no api changes)  
- [ ] Build related changes  
- [ ] CI related changes  
- [ ] Documentation content changes  
- [ ] TranquilityBase application / infrastructure changes  
- [ ] Other... Please describe:  


## Purpose 
This is as part of the Activator Deploy milestone


  
## Reviewers  
@rjmco , @scottholmangft , @wills-gft , @afamgft 
  
  ## Checklist  
 - [*] This PR is linked to one or more issues.  #279 
 - [ ] This PR has been tested (attach evidence if possible).  
 - [ ] This PR has passed style guidelines.  

[adct@tb-kube-proxy-3wn5 ~]$ kubectl get namespaces
NAME              STATUS   AGE
cicd              Active   99m
default           Active   109m
istio-operator    Active   103m
istio-system      Active   102m
kube-node-lease   Active   109m
kube-public       Active   109m
kube-system       Active   109m
ssp               Active   99m
[adct@tb-kube-proxy-3wn5 ~]$ kubectl get pods -n cicd
NAME                              READY   STATUS    RESTARTS   AGE
jenkins-master-79bfdf8c85-bfpxh   1/1     Running   0          94m
[adct@tb-kube-proxy-3wn5 ~]$ 

above is the extra from the test deployment showing the namespaces and the jenkins master running in the cicd namespace


Also the way to access Jenkins after it is installed is through the bastion host vms (IAP) and the ip of the jenkins load balancer service. Next task would be to configure the connection between DAC and Jenkins and also register a dns name for the jenkins server