### PR TITLE
changed the node machine type and boot disk size

### DIFF
--- a/tb-gcp-tr/kubernetes-cluster-creation/variables.tf
+++ b/tb-gcp-tr/kubernetes-cluster-creation/variables.tf
@@ -39,7 +39,7 @@ variable "cluster_pool_name" {
 
 variable "cluster_machine_type" {
   type    = string
-  default = "n1-standard-2"
+  default = "n1-standard-4"
 }
 
 variable "cluster_enable_private_nodes" {
@@ -110,7 +110,7 @@ variable "cluster_daily_maintenance_start" {
 
 variable "cluster_node_disk_size" {
   type    = string
-  default = "10"
+  default = "30"
 }
 
 variable "cluster_oauth_scopes" {


### PR DESCRIPTION
Changed the node machine type and boot disk size to match the resource that is required to run the SSP and Jenkins master changed from n1-standard-2 to n1-standard-4 and the boot disk size from 10G to 30G the cost is double of what is present at the moment from 0.64 hourly per node to 0.134 hourly per node but with the present setup we anyway had the nodes autoscaled to 5-6 nodes because of the initial load.

## PR Type  
Changed the machine type and boot disk size in the kubernetes-cluster-creation module/variables.tf file
  
Please check the boxes that applies to this PR.  
  
- [*] Bugfix  
- [ ] Feature  
- [ ] Code style update (formatting, local variables)  
- [ ] Refactoring (no functional changes, no api changes)  
- [ ] Build related changes  
- [ ] CI related changes  
- [ ] Documentation content changes  
- [ ] TranquilityBase application / infrastructure changes  
- [ ] Other... Please describe:  


## Purpose 
Describe the problem or feature with a **link** to the issues.    
Also please describe which sections of the code do what and for what reason.  
  
## Reviewers  
 - **Reviewer A** please review this part.  
 - **Review B** please review this part.  
  
  ## Checklist  
 - [ ] This PR is linked to one or more issues.  
 - [ ] This PR has been tested (attach evidence if possible).  
 - [ ] This PR has passed style guidelines.  
