### PR TITLE
Issue 299

### DIFF
--- a/tb-gcp-deploy/pack/packer-no-itop.json
+++ b/tb-gcp-deploy/pack/packer-no-itop.json
@@ -115,6 +115,11 @@
       "source": "{{user `tb_repos_root_path`}}/tb-gcp-tr/shared-dac",
       "destination": "tb-gcp-tr/"
     },
+    { 
+      "type": "file", 
+      "source": "{{user `tb_repos_root_path`}}/tb-gcp-tr/audit-logging",
+      "destination": "tb-gcp-tr/"
+    },
     {
       "type": "file",
       "source": "{{user `tb_repos_root_path`}}/tb-gcp-tr/.gitignore",

--- a/tb-gcp-tr/audit-logging/main.tf
+++ b/tb-gcp-tr/audit-logging/main.tf
@@ -61,7 +61,7 @@ resource "google_logging_folder_sink" "audit_log_sink" {
   # export to log bucket
   destination = "storage.googleapis.com/${google_storage_bucket.audit_log_bucket.name}"
 
-  filter = "folders/769716832916/logs/cloudaudit.googleapis.com" 
+  filter = "logName:folders/769716832916/logs/cloudaudit.googleapis.com" 
 }  
 
 ###give service account permissions to bucket

--- a/tb-gcp-tr/audit-logging/main.tf
+++ b/tb-gcp-tr/audit-logging/main.tf
@@ -24,11 +24,6 @@ resource "google_storage_bucket" "audit_log_bucket" {
   name     = join("", [var.bucketprefix, random_id.logging.hex])
   location = var.region
 
-  retention_policy {
-    is_locked = var.bucketlock
-    retention_period = var.retentionperiod
-  }
-
   lifecycle_rule {
     condition {
       age = var.changestorageage
@@ -61,7 +56,7 @@ resource "google_logging_folder_sink" "audit_log_sink" {
   # export to log bucket
   destination = "storage.googleapis.com/${google_storage_bucket.audit_log_bucket.name}"
 
-  filter = "logName:folders/769716832916/logs/cloudaudit.googleapis.com" 
+  filter      = "logName=(cloudaudit.googleapis.com%2Factivity OR cloudaudit.googleapis.com%2Fdata_access OR cloudaudit.googleapis.com%2Fsystem_event)" 
 }  
 
 ###give service account permissions to bucket

--- a/tb-gcp-tr/audit-logging/main.tf
+++ b/tb-gcp-tr/audit-logging/main.tf
@@ -56,7 +56,7 @@ resource "google_logging_folder_sink" "audit_log_sink" {
   # export to log bucket
   destination = "storage.googleapis.com/${google_storage_bucket.audit_log_bucket.name}"
 
-  filter      = "logName=folders/${root_id}/logs/cloudaudit.googleapis.com%2Factivity OR folders/${root_id}/logs/cloudaudit.googleapis.com%2Fdata_access OR folders/${root_id}/logs/cloudaudit.googleapis.com%2Fsystem_event" 
+  filter      = "logName=(folders/${root_id}/logs/cloudaudit.googleapis.com%2Factivity OR folders/${root_id}/logs/cloudaudit.googleapis.com%2Fdata_access OR folders/${root_id}/logs/cloudaudit.googleapis.com%2Fsystem_event)" 
 }  
 
 ###give service account permissions to bucket

--- a/tb-gcp-tr/audit-logging/main.tf
+++ b/tb-gcp-tr/audit-logging/main.tf
@@ -23,7 +23,10 @@ resource "google_storage_bucket" "audit_log_bucket" {
   project  = var.logging_project_id
   name     = join("", [var.bucketprefix, random_id.logging.hex])
   location = var.region
-  is_locked = var.bucketlock
+
+  retention_policy {
+    is_locked = var.bucketlock
+  }
 
   lifecycle_rule {
     condition {

--- a/tb-gcp-tr/audit-logging/main.tf
+++ b/tb-gcp-tr/audit-logging/main.tf
@@ -56,7 +56,7 @@ resource "google_logging_folder_sink" "audit_log_sink" {
   # export to log bucket
   destination = "storage.googleapis.com/${google_storage_bucket.audit_log_bucket.name}"
 
-  filter = "logName=(folders/${var.root_id}/logs/cloudaudit.googleapis.com%2Factivity OR folders/${var.root_id}/logs/cloudaudit.googleapis.com%2Fdata_access OR folders/${var.root_id}/logs/cloudaudit.googleapis.com%2Fsystem_event)"
+  filter = "logName=(folders/${var.root_id}/logs/cloudaudit.googleapis.com%2Factivity OR folders/${var.root_id}/logs/cloudaudit.googleapis.com%2Fdata_access)"
 }
 
 ###give service account permissions to bucket

--- a/tb-gcp-tr/audit-logging/main.tf
+++ b/tb-gcp-tr/audit-logging/main.tf
@@ -51,19 +51,19 @@ resource "google_storage_bucket" "audit_log_bucket" {
 ###create sink to push logs to bucket in the logging project
 resource "google_logging_folder_sink" "audit_log_sink" {
   folder = var.root_id
-  name    = var.sinkname
+  name   = var.sinkname
 
   # export to log bucket
   destination = "storage.googleapis.com/${google_storage_bucket.audit_log_bucket.name}"
 
-  filter      = "logName=(folders/${var.root_id}/logs/cloudaudit.googleapis.com%2Factivity OR folders/${var.root_id}/logs/cloudaudit.googleapis.com%2Fdata_access OR folders/${var.root_id}/logs/cloudaudit.googleapis.com%2Fsystem_event)" 
-}  
+  filter = "logName=(folders/${var.root_id}/logs/cloudaudit.googleapis.com%2Factivity OR folders/${var.root_id}/logs/cloudaudit.googleapis.com%2Fdata_access OR folders/${var.root_id}/logs/cloudaudit.googleapis.com%2Fsystem_event)"
+}
 
 ###give service account permissions to bucket
 resource "google_project_iam_binding" "bucket_audit_log_writer" {
   project = var.logging_project_id
   members = [google_logging_folder_sink.audit_log_sink.writer_identity]
-  role = "roles/storage.objectCreator"
+  role    = "roles/storage.objectCreator"
 
   depends_on = [google_logging_folder_sink.audit_log_sink]
 }

--- a/tb-gcp-tr/audit-logging/main.tf
+++ b/tb-gcp-tr/audit-logging/main.tf
@@ -60,6 +60,8 @@ resource "google_logging_folder_sink" "audit_log_sink" {
 
   # export to log bucket
   destination = "storage.googleapis.com/${google_storage_bucket.audit_log_bucket.name}"
+
+  filter = "folders/769716832916/logs/cloudaudit.googleapis.com" 
 }  
 
 ###give service account permissions to bucket

--- a/tb-gcp-tr/audit-logging/main.tf
+++ b/tb-gcp-tr/audit-logging/main.tf
@@ -15,13 +15,13 @@
 #CREATE-AUDIT-LOGGING
 
 resource "random_id" "logging" {
-  byte_length = 4
+  byte_length = var.randomidlen
 }
 
 ###create the log bucket
 resource "google_storage_bucket" "log-bucket" {
-  project  = var.shared_telemetry_project_id
-  name     = "audit-log-bucket-${random_id.logging.hex}"
+  project  = var.logging_project_id
+  name     = concat([var.bucketprefix, ${random_id.logging.hex]})
   location = var.region
 
   lifecycle_rule {
@@ -44,14 +44,14 @@ resource "google_storage_bucket" "log-bucket" {
   }
 
   labels = {
-    purpose = "sends_to_collect_admin_read_data_write_data_read_audit_logs"
+    Fuction = var.labelfuction
   }
 }
 
-###create sink to push logs to bucket in telemtry project
-resource "google_logging_folder_sink" "audit_log_sink" {
+###create sink to push logs to bucket in the logging project
+resource "google_logging_folder_sink" "log_sink" {
   folder = var.root_id
-  name    = "audit_log_sink"
+  name    = var.sinkname
 
   # export to log bucket
   destination = "storage.googleapis.com/${google_storage_bucket.log-bucket.name}"
@@ -60,13 +60,13 @@ resource "google_logging_folder_sink" "audit_log_sink" {
   unique_writer_identity = true
 }
 
-#Gives the log writer permissions to bucket
+###gives the log writer permissions to bucket
 resource "google_project_iam_binding" "log-writer" {
-  project = var.shared_telemetry_project_id
+  project = var.logging_project_id
   role    = "roles/storage.objectCreator"
 
   members = [
-    google_logging_project_sink.audit_log_sink.writer_identity,
+    google_logging_project_sink.log_sink.writer_identity,
   ]
 }
 

--- a/tb-gcp-tr/audit-logging/main.tf
+++ b/tb-gcp-tr/audit-logging/main.tf
@@ -63,7 +63,7 @@ resource "google_project_iam_binding" "log-writer" {
   role    = "roles/storage.objectCreator"
 
   members = [
-      google_logging_folder_sink.log-sink.writer_identity
+      google_logging_folder_sink.log_sink.writer_identity
   ]
 }
 

--- a/tb-gcp-tr/audit-logging/main.tf
+++ b/tb-gcp-tr/audit-logging/main.tf
@@ -56,7 +56,7 @@ resource "google_logging_folder_sink" "audit_log_sink" {
   # export to log bucket
   destination = "storage.googleapis.com/${google_storage_bucket.audit_log_bucket.name}"
 
-  filter      = "logName=(cloudaudit.googleapis.com%2Factivity OR cloudaudit.googleapis.com%2Fdata_access OR cloudaudit.googleapis.com%2Fsystem_event)" 
+  filter      = "logName=folders/${root_id}/logs/cloudaudit.googleapis.com%2Factivity OR folders/${root_id}/logs/cloudaudit.googleapis.com%2Fdata_access OR folders/${root_id}/logs/cloudaudit.googleapis.com%2Fsystem_event" 
 }  
 
 ###give service account permissions to bucket

--- a/tb-gcp-tr/audit-logging/main.tf
+++ b/tb-gcp-tr/audit-logging/main.tf
@@ -64,18 +64,3 @@ resource "google_storage_bucket_iam_binding" "bucket_audit_log_writer" {
   members = [google_logging_folder_sink.audit_log_sink.writer_identity]
   role = "roles/storage.objectCreator"
 }
-
-
-###gives the log writer permissions to bucket
-#resource "google_project_iam_binding" "audit_log_writer" {
- # project = var.logging_project_id
-  #role    = "roles/storage.objectCreator"
-
-  #members = [
-  #    google_logging_folder_sink.audit_log_sink.writer_identity
- # ]
-#}
-
-
-
-

--- a/tb-gcp-tr/audit-logging/main.tf
+++ b/tb-gcp-tr/audit-logging/main.tf
@@ -21,7 +21,7 @@ resource "random_id" "logging" {
 ###create the log bucket
 resource "google_storage_bucket" "log-bucket" {
   project  = var.logging_project_id
-  name     = concat([var.bucketprefix, ${random_id.logging.hex]})
+  name     = join("", [var.bucketprefix, random_id.logging.hex])
   location = var.region
 
   lifecycle_rule {

--- a/tb-gcp-tr/audit-logging/main.tf
+++ b/tb-gcp-tr/audit-logging/main.tf
@@ -56,7 +56,7 @@ resource "google_logging_folder_sink" "audit_log_sink" {
   # export to log bucket
   destination = "storage.googleapis.com/${google_storage_bucket.audit_log_bucket.name}"
 
-  filter      = "logName=(folders/${root_id}/logs/cloudaudit.googleapis.com%2Factivity OR folders/${root_id}/logs/cloudaudit.googleapis.com%2Fdata_access OR folders/${root_id}/logs/cloudaudit.googleapis.com%2Fsystem_event)" 
+  filter      = "logName=(folders/${var.root_id}/logs/cloudaudit.googleapis.com%2Factivity OR folders/${var.root_id}/logs/cloudaudit.googleapis.com%2Fdata_access OR folders/${var.root_id}/logs/cloudaudit.googleapis.com%2Fsystem_event)" 
 }  
 
 ###give service account permissions to bucket

--- a/tb-gcp-tr/audit-logging/main.tf
+++ b/tb-gcp-tr/audit-logging/main.tf
@@ -24,22 +24,21 @@ resource "google_storage_bucket" "audit_log_bucket" {
   name     = join("", [var.bucketprefix, random_id.logging.hex])
   location = var.region
 
-  lifecycle_rule {
-    condition {
-      age = var.changestorageage
-    }
-    action {
-      type          = "SetStorageClass"
-      storage_class = var.storageclass
-    }
-  }
+  dynamic "lifecycle_rule" {
+    for_each = [for c in var.lifecyclerule : {
+      age           = c.age
+      type          = c.type
+      storage_class = c.storage_class
+    }]
 
-  lifecycle_rule {
-    condition {
-      age = var.deleteage
-    }
-    action {
-      type = "Delete"
+    content {
+      action {
+        type          = lifecycle_rule.value.type
+        storage_class = lifecycle_rule.value.storage_class
+      }
+      condition {
+        age = lifecycle_rule.value.age
+      }
     }
   }
 

--- a/tb-gcp-tr/audit-logging/main.tf
+++ b/tb-gcp-tr/audit-logging/main.tf
@@ -21,7 +21,7 @@ resource "random_id" "logging" {
 ###create the log bucket
 resource "google_storage_bucket" "log-bucket" {
   project  = var.shared_telemetry_project_id
-  name     = "audit-log-bucket-${random_id.project.hex}"
+  name     = "audit-log-bucket-${random_id.logging.hex}"
   location = var.region
 
   lifecycle_rule {
@@ -66,7 +66,7 @@ resource "google_project_iam_binding" "log-writer" {
   role    = "roles/storage.objectCreator"
 
   members = [
-    google_logging_project_sink.log_sink.writer_identity,
+    google_logging_project_sink.audit_log_sink.writer_identity,
   ]
 }
 

--- a/tb-gcp-tr/audit-logging/main.tf
+++ b/tb-gcp-tr/audit-logging/main.tf
@@ -56,17 +56,13 @@ resource "google_logging_folder_sink" "log_sink" {
   # export to log bucket
   destination = "storage.googleapis.com/${google_storage_bucket.log-bucket.name}"
 
-  # Use a unique writer (creates a unique service account used for writing)
-  unique_writer_identity = true
-}
-
 ###gives the log writer permissions to bucket
 resource "google_project_iam_binding" "log-writer" {
   project = var.logging_project_id
   role    = "roles/storage.objectCreator"
 
   members = [
-    google_logging_project_sink.log_sink.writer_identity,
+      google_logging_folder_sink.log-sink.writer_identity
   ]
 }
 

--- a/tb-gcp-tr/audit-logging/main.tf
+++ b/tb-gcp-tr/audit-logging/main.tf
@@ -26,6 +26,7 @@ resource "google_storage_bucket" "audit_log_bucket" {
 
   retention_policy {
     is_locked = var.bucketlock
+    retention_period = var.retentionperiod
   }
 
   lifecycle_rule {

--- a/tb-gcp-tr/audit-logging/main.tf
+++ b/tb-gcp-tr/audit-logging/main.tf
@@ -58,7 +58,7 @@ resource "google_logging_folder_sink" "log_sink" {
 }  
 
 ###gives the log writer permissions to bucket
-resource "google_project_iam_binding" "log-writer" {
+resource "google_project_iam_binding" "log_writer" {
   project = var.logging_project_id
   role    = "roles/storage.objectCreator"
 

--- a/tb-gcp-tr/audit-logging/main.tf
+++ b/tb-gcp-tr/audit-logging/main.tf
@@ -60,8 +60,10 @@ resource "google_logging_folder_sink" "audit_log_sink" {
 }  
 
 ###give service account permissions to bucket
-resource "google_storage_bucket_iam_binding" "bucket_audit_log_writer" {
-  bucket = google_storage_bucket.audit_log_bucket.name
+resource "google_project_iam_binding" "bucket_audit_log_writer" {
+  project = var.logging_project_id
   members = [google_logging_folder_sink.audit_log_sink.writer_identity]
   role = "roles/storage.objectCreator"
+
+  depends_on = [google_logging_folder_sink.audit_log_sink]
 }

--- a/tb-gcp-tr/audit-logging/main.tf
+++ b/tb-gcp-tr/audit-logging/main.tf
@@ -23,6 +23,7 @@ resource "google_storage_bucket" "audit_log_bucket" {
   project  = var.logging_project_id
   name     = join("", [var.bucketprefix, random_id.logging.hex])
   location = var.region
+  is_locked = var.bucketlock
 
   lifecycle_rule {
     condition {

--- a/tb-gcp-tr/audit-logging/main.tf
+++ b/tb-gcp-tr/audit-logging/main.tf
@@ -55,6 +55,7 @@ resource "google_logging_folder_sink" "log_sink" {
 
   # export to log bucket
   destination = "storage.googleapis.com/${google_storage_bucket.log-bucket.name}"
+}  
 
 ###gives the log writer permissions to bucket
 resource "google_project_iam_binding" "log-writer" {

--- a/tb-gcp-tr/audit-logging/main.tf
+++ b/tb-gcp-tr/audit-logging/main.tf
@@ -19,7 +19,7 @@ resource "random_id" "logging" {
 }
 
 ###create the log bucket
-resource "google_storage_bucket" "log-bucket" {
+resource "google_storage_bucket" "log_bucket" {
   project  = var.logging_project_id
   name     = join("", [var.bucketprefix, random_id.logging.hex])
   location = var.region
@@ -44,7 +44,7 @@ resource "google_storage_bucket" "log-bucket" {
   }
 
   labels = {
-    Fuction = var.labelfuction
+    fuction = var.labelfuction
   }
 }
 
@@ -54,7 +54,7 @@ resource "google_logging_folder_sink" "log_sink" {
   name    = var.sinkname
 
   # export to log bucket
-  destination = "storage.googleapis.com/${google_storage_bucket.log-bucket.name}"
+  destination = "storage.googleapis.com/${google_storage_bucket.log_bucket.name}"
 }  
 
 ###gives the log writer permissions to bucket

--- a/tb-gcp-tr/audit-logging/main.tf
+++ b/tb-gcp-tr/audit-logging/main.tf
@@ -1,0 +1,75 @@
+# Copyright 2019 The Tranquility Base Authors
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#CREATE-AUDIT-LOGGING
+
+resource "random_id" "logging" {
+  byte_length = 4
+}
+
+###create the log bucket
+resource "google_storage_bucket" "log-bucket" {
+  project  = var.shared_telemetry_project_id
+  name     = "audit-log-bucket-${random_id.project.hex}"
+  location = var.region
+
+  lifecycle_rule {
+    condition {
+      age = var.changestorageage
+    }
+    action {
+      type          = "SetStorageClass"
+      storage_class = var.storageclass
+    }
+  }
+
+  lifecycle_rule {
+    condition {
+      age = var.deleteage
+    }
+    action {
+      type = "Delete"
+    }
+  }
+
+  labels = {
+    purpose = "sends_to_collect_admin_read_data_write_data_read_audit_logs"
+  }
+}
+
+###create sink to push logs to bucket in telemtry project
+resource "google_logging_folder_sink" "audit_log_sink" {
+  folder = var.root_id
+  name    = "audit_log_sink"
+
+  # export to log bucket
+  destination = "storage.googleapis.com/${google_storage_bucket.log-bucket.name}"
+
+  # Use a unique writer (creates a unique service account used for writing)
+  unique_writer_identity = true
+}
+
+#Gives the log writer permissions to bucket
+resource "google_project_iam_binding" "log-writer" {
+  project = var.shared_telemetry_project_id
+  role    = "roles/storage.objectCreator"
+
+  members = [
+    google_logging_project_sink.log_sink.writer_identity,
+  ]
+}
+
+
+
+

--- a/tb-gcp-tr/audit-logging/variables.tf
+++ b/tb-gcp-tr/audit-logging/variables.tf
@@ -50,11 +50,11 @@ variable "deleteage" {
 }
 variable "bucketprefix" {
     type    = "string"
-    default = "logbucket-"
+    default = "auditlogbucket-"
 }
 variable "labelfuction" {
     type    = "string"
-    default = "bucket_to_store_logs"
+    default = "bucket_to_store_root_folder_audit_logs"
 }
 variable "sinkname" {
     type    = "string"

--- a/tb-gcp-tr/audit-logging/variables.tf
+++ b/tb-gcp-tr/audit-logging/variables.tf
@@ -40,14 +40,14 @@ variable "deleteage" {
     default = "365"
 }
 variable "bucketprefix" {
-    default = ""
+    default = "logbucket-"
 }
-variable "labelfuction {
-    default = ""
-}"
+variable "labelfuction" {
+    default = "bucket_to_store_logs"
+}
 variable "sinkname" {
-    default = ""
+    default = "log-sink"
 }
 variabe "randomidlen" {
-    default = ""
+    default = "6"
 }

--- a/tb-gcp-tr/audit-logging/variables.tf
+++ b/tb-gcp-tr/audit-logging/variables.tf
@@ -18,7 +18,7 @@ variable "region" {
 variable "root_id" {
     default = ""
 }
-variable "shared_telemetry_project_id" {
+variable "logging_project_id" {
     default = ""
 }
 variable "logprojectid" {
@@ -38,4 +38,16 @@ variable "storageclass" {
 }
 variable "deleteage" {
     default = "365"
+}
+variable "bucketprefix" {
+    default = ""
+}
+variable "labelfuction {
+    default = ""
+}"
+variable "sinkname" {
+    default = ""
+}
+variabe "randomidlen" {
+    default = ""
 }

--- a/tb-gcp-tr/audit-logging/variables.tf
+++ b/tb-gcp-tr/audit-logging/variables.tf
@@ -54,7 +54,7 @@ variable "labelfuction" {
 }
 variable "sinkname" {
     type    = "string"
-    default = "log_sink"
+    default = "log_sink_1"
 }
 variable "randomidlen" {
     type    = "string"

--- a/tb-gcp-tr/audit-logging/variables.tf
+++ b/tb-gcp-tr/audit-logging/variables.tf
@@ -64,3 +64,7 @@ variable "bucketlock" {
     type = "string"
     default = "true"
 }
+variable "retentionperiod" {
+    type = "string"
+    default = "30"
+}

--- a/tb-gcp-tr/audit-logging/variables.tf
+++ b/tb-gcp-tr/audit-logging/variables.tf
@@ -48,6 +48,6 @@ variable "labelfuction" {
 variable "sinkname" {
     default = "log-sink"
 }
-variabe "randomidlen" {
+variable "randomidlen" {
     default = "6"
 }

--- a/tb-gcp-tr/audit-logging/variables.tf
+++ b/tb-gcp-tr/audit-logging/variables.tf
@@ -60,10 +60,3 @@ variable "randomidlen" {
     type    = "string"
     default = "6"
 }
-variable "bucketlock" {
-    type = "string"
-    default = "true"
-}
-variable "retentionperiod" {
-    default = "31536000" #365 days
-}

--- a/tb-gcp-tr/audit-logging/variables.tf
+++ b/tb-gcp-tr/audit-logging/variables.tf
@@ -15,7 +15,7 @@
 variable "region" {
     default = ""
 }
-variable "rootid" {
+variable "root_id" {
     default = ""
 }
 variable "shared_telemetry_project_id" {

--- a/tb-gcp-tr/audit-logging/variables.tf
+++ b/tb-gcp-tr/audit-logging/variables.tf
@@ -66,5 +66,5 @@ variable "bucketlock" {
 }
 variable "retentionperiod" {
     type = "string"
-    default = "30"
+    default = "365d"
 }

--- a/tb-gcp-tr/audit-logging/variables.tf
+++ b/tb-gcp-tr/audit-logging/variables.tf
@@ -32,18 +32,6 @@ variable "location" {
   type    = "string"
   default = "EUROPE-WEST2"
 }
-variable "changestorageage" {
-  type    = "string"
-  default = "30"
-}
-variable "storageclass" {
-  type    = "string"
-  default = "NEARLINE"
-}
-variable "deleteage" {
-  type    = "string"
-  default = "365"
-}
 variable "bucketprefix" {
   type    = "string"
   default = "auditlogbucket-"
@@ -59,4 +47,20 @@ variable "sinkname" {
 variable "randomidlen" {
   type    = "string"
   default = "6"
+}
+variable "lifecyclerule" {
+  type = list(map(string))
+
+  default = [
+    {
+      type          = "SetStorageClass"
+      storage_class = "NEARLINE"
+      age           = "30"
+    },
+    {
+      type          = "Delete"
+      storage_class = ""
+      age           = "365"
+    }
+  ]
 }

--- a/tb-gcp-tr/audit-logging/variables.tf
+++ b/tb-gcp-tr/audit-logging/variables.tf
@@ -65,6 +65,5 @@ variable "bucketlock" {
     default = "true"
 }
 variable "retentionperiod" {
-    type = "string"
-    default = "365d"
+    default = "31536000" #365 days
 }

--- a/tb-gcp-tr/audit-logging/variables.tf
+++ b/tb-gcp-tr/audit-logging/variables.tf
@@ -46,7 +46,7 @@ variable "labelfuction" {
     default = "bucket_to_store_logs"
 }
 variable "sinkname" {
-    default = "log-sink"
+    default = "log_sink"
 }
 variable "randomidlen" {
     default = "6"

--- a/tb-gcp-tr/audit-logging/variables.tf
+++ b/tb-gcp-tr/audit-logging/variables.tf
@@ -64,3 +64,7 @@ variable "randomidlen" {
     type    = "string"
     default = "6"
 }
+variable "bucketlock" {
+    type = "string"
+    default = "true"
+}

--- a/tb-gcp-tr/audit-logging/variables.tf
+++ b/tb-gcp-tr/audit-logging/variables.tf
@@ -24,10 +24,6 @@ variable "logging_project_id" {
     type    = "string"
     default = ""
 }
-variable "logprojectid" {
-    type    = "string"
-    default = ""
-}
 variable "services" {
     type    = "string"
     default = "allServices"

--- a/tb-gcp-tr/audit-logging/variables.tf
+++ b/tb-gcp-tr/audit-logging/variables.tf
@@ -13,41 +13,54 @@
 # limitations under the License.
 
 variable "region" {
+    type    = "string"
     default = ""
 }
 variable "root_id" {
+    type    = "string"
     default = ""
 }
 variable "logging_project_id" {
+    type    = "string"
     default = ""
 }
 variable "logprojectid" {
+    type    = "string"
     default = ""
 }
 variable "services" {
+    type    = "string"
     default = "allServices"
 }
 variable "location" {
+    type    = "string"
     default = "EUROPE-WEST2"
 }
 variable "changestorageage" {
+    type    = "string"
     default = "30"
 }
 variable "storageclass" {
+    type    = "string"
     default = "NEARLINE"
 }
 variable "deleteage" {
+    type    = "string"
     default = "365"
 }
 variable "bucketprefix" {
+    type    = "string"
     default = "logbucket-"
 }
 variable "labelfuction" {
+    type    = "string"
     default = "bucket_to_store_logs"
 }
 variable "sinkname" {
+    type    = "string"
     default = "log_sink"
 }
 variable "randomidlen" {
+    type    = "string"
     default = "6"
 }

--- a/tb-gcp-tr/audit-logging/variables.tf
+++ b/tb-gcp-tr/audit-logging/variables.tf
@@ -13,50 +13,50 @@
 # limitations under the License.
 
 variable "region" {
-    type    = "string"
-    default = ""
+  type    = "string"
+  default = ""
 }
 variable "root_id" {
-    type    = "string"
-    default = ""
+  type    = "string"
+  default = ""
 }
 variable "logging_project_id" {
-    type    = "string"
-    default = ""
+  type    = "string"
+  default = ""
 }
 variable "services" {
-    type    = "string"
-    default = "allServices"
+  type    = "string"
+  default = "allServices"
 }
 variable "location" {
-    type    = "string"
-    default = "EUROPE-WEST2"
+  type    = "string"
+  default = "EUROPE-WEST2"
 }
 variable "changestorageage" {
-    type    = "string"
-    default = "30"
+  type    = "string"
+  default = "30"
 }
 variable "storageclass" {
-    type    = "string"
-    default = "NEARLINE"
+  type    = "string"
+  default = "NEARLINE"
 }
 variable "deleteage" {
-    type    = "string"
-    default = "365"
+  type    = "string"
+  default = "365"
 }
 variable "bucketprefix" {
-    type    = "string"
-    default = "auditlogbucket-"
+  type    = "string"
+  default = "auditlogbucket-"
 }
 variable "labelfuction" {
-    type    = "string"
-    default = "bucket_to_store_root_folder_audit_logs"
+  type    = "string"
+  default = "bucket_to_store_root_folder_audit_logs"
 }
 variable "sinkname" {
-    type    = "string"
-    default = "log_sink_1"
+  type    = "string"
+  default = "log_sink_1"
 }
 variable "randomidlen" {
-    type    = "string"
-    default = "6"
+  type    = "string"
+  default = "6"
 }

--- a/tb-gcp-tr/audit-logging/variables.tf
+++ b/tb-gcp-tr/audit-logging/variables.tf
@@ -1,0 +1,41 @@
+# Copyright 2019 The Tranquility Base Authors
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "region" {
+    default = ""
+}
+variable "rootid" {
+    default = ""
+}
+variable "shared_telemetry_project_id" {
+    default = ""
+}
+variable "logprojectid" {
+    default = ""
+}
+variable "services" {
+    default = "allServices"
+}
+variable "location" {
+    default = "EUROPE-WEST2"
+}
+variable "changestorageage" {
+    default = "30"
+}
+variable "storageclass" {
+    default = "NEARLINE"
+}
+variable "deleteage" {
+    default = "365"
+}

--- a/tb-gcp-tr/landingZone/no-itop/input.tfvars
+++ b/tb-gcp-tr/landingZone/no-itop/input.tfvars
@@ -122,5 +122,5 @@ ec_iam_service_account_roles = [
 "roles/resourcemanager.projectIamAdmin"]
 
 #DAC Services
-sharedservice_namespace_yaml_path = "/opt/tb/repo/tb-gcp-tr/shared-dac/namespaces.yaml"
+sharedservice_namespace_yaml_path     = "/opt/tb/repo/tb-gcp-tr/shared-dac/namespaces.yaml"
 sharedservice_jenkinsmaster_yaml_path = "/opt/tb/repo/tb-gcp-tr/shared-dac/jenkins-master.yaml"

--- a/tb-gcp-tr/landingZone/no-itop/main.tf
+++ b/tb-gcp-tr/landingZone/no-itop/main.tf
@@ -76,9 +76,9 @@ module "shared_projects" {
 module "audit_logging" {
   source = "../../audit-logging"
   
-  region = var.region
-  shared_telemetry_project_id = module.shared_projects.shared_telemetry_id
-  root_id                     = var.root_id
+  region             = var.region
+  logging_project_id = module.shared_projects.shared_telemetry_id
+  root_id            = var.root_id
 }
 
 module "apis_activation" {

--- a/tb-gcp-tr/landingZone/no-itop/main.tf
+++ b/tb-gcp-tr/landingZone/no-itop/main.tf
@@ -73,6 +73,14 @@ module "shared_projects" {
   shared_bastion_project_name    = var.shared_bastion_project_name
 }
 
+module "audit_logging" {
+  source = "../../audit-logging"
+  
+  region = var.region
+  shared_telemetry_project_id = module.shared_projects.shared_telemetry_id
+  root_id                     = var.root_id
+}
+
 module "apis_activation" {
   source = "../../apis-activation"
   bastion_project_id       = module.shared_projects.shared_bastion_id

--- a/tb-gcp-tr/landingZone/no-itop/main.tf
+++ b/tb-gcp-tr/landingZone/no-itop/main.tf
@@ -75,14 +75,14 @@ module "shared_projects" {
 
 module "audit_logging" {
   source = "../../audit-logging"
-  
+
   region             = var.region
   logging_project_id = module.shared_projects.shared_telemetry_id
   root_id            = var.root_id
 }
 
 module "apis_activation" {
-  source = "../../apis-activation"
+  source                   = "../../apis-activation"
   bastion_project_id       = module.shared_projects.shared_bastion_id
   host_project_id          = module.shared_projects.shared_networking_id
   eagle_console_project_id = module.shared_projects.shared_ec_id

--- a/tb-gcp-tr/shared-bastion/main.tf
+++ b/tb-gcp-tr/shared-bastion/main.tf
@@ -96,7 +96,7 @@ data "google_compute_image" "debian_image" {
 }
 
 data "google_compute_image" "centos_image" {
-  family = "centos-7"
+  family  = "centos-7"
   project = "centos-cloud"
 }
 
@@ -204,8 +204,8 @@ resource "google_compute_instance_group_manager" "windows_bastion_group" {
 
 //Create instance template for the Squid Proxy instance
 resource "google_compute_instance_template" "squid_proxy_template" {
-  project      = var.shared_bastion_id
-  name         = "tb-kube-proxy-template"
+  project = var.shared_bastion_id
+  name    = "tb-kube-proxy-template"
 
   machine_type = "n1-standard-2"
 
@@ -228,7 +228,7 @@ resource "google_compute_instance_template" "squid_proxy_template" {
     scopes = var.scopes
   }
 
-    metadata_startup_script = file("${path.module}/squid_startup.sh")
+  metadata_startup_script = file("${path.module}/squid_startup.sh")
 
 }
 

--- a/tb-gcp-tr/shared-vpc/main.tf
+++ b/tb-gcp-tr/shared-vpc/main.tf
@@ -32,13 +32,13 @@ resource "google_compute_network" "shared_network" {
 }
 
 resource "google_compute_subnetwork" "standard" {
-  count         = length(var.standard_network_subnets)
-  name          = var.standard_network_subnets[count.index]["name"]
-  ip_cidr_range = var.standard_network_subnets[count.index]["cidr"]
-  region        = var.region
+  count                    = length(var.standard_network_subnets)
+  name                     = var.standard_network_subnets[count.index]["name"]
+  ip_cidr_range            = var.standard_network_subnets[count.index]["cidr"]
+  region                   = var.region
   private_ip_google_access = true
-  project       = var.host_project_id
-  network       = google_compute_network.shared_network.name
+  project                  = var.host_project_id
+  network                  = google_compute_network.shared_network.name
 
   log_config {
     aggregation_interval = "INTERVAL_5_SEC"

--- a/tb-marketplace/tb-config-creator/tb-config-creator
+++ b/tb-marketplace/tb-config-creator/tb-config-creator
@@ -181,6 +181,16 @@ folder_id_entry=$(gcloud resource-manager folders create --display-name="${TBASE
 IFS='/' read -ra split_array <<< "$folder_id_entry"
 tb_folder_id="$(echo ${split_array[1]} | sed 's/[^0-9]*//g')"
 
+#Add auditing to at folder level
+gcloud resource-manager folders get-iam-policy "${tb_folder_id}" > rootfolderiampolicy.yaml
+sed -i "1 i\auditConfigs:" rootfolderiampolicy.yaml
+sed -i "2 i\- auditLogConfigs:" rootfolderiampolicy.yaml
+sed -i "3 i\  - logType: ADMIN_READ" rootfolderiampolicy.yaml
+sed -i "4 i\  - logType: DATA_WRITE" rootfolderiampolicy.yaml
+sed -i "5 i\  - logType: DATA_READ" rootfolderiampolicy.yaml
+sed -i "6 i\  service: allServices" rootfolderiampolicy.yaml
+gcloud resource-manager folders set-iam-policy "${tb_folder_id}" rootfolderiampolicy.yaml 
+rm rootfolderiampolicy.yaml
 
 echo "Creating project..."
 if [[ -n ${ADMIN}  ]]; then

--- a/tb-marketplace/tb-config-creator/tb-config-creator
+++ b/tb-marketplace/tb-config-creator/tb-config-creator
@@ -223,6 +223,8 @@ gcloud resource-manager folders add-iam-policy-binding "${tb_folder_id}" --membe
 gcloud resource-manager folders add-iam-policy-binding "${tb_folder_id}" --member=serviceAccount:"${SA_EMAIL}" --role=roles/billing.projectManager --format=none
 gcloud resource-manager folders add-iam-policy-binding "${tb_folder_id}" --member=serviceAccount:"${SA_EMAIL}" --role=roles/compute.networkAdmin --format=none
 gcloud resource-manager folders add-iam-policy-binding "${tb_folder_id}" --member=serviceAccount:"${SA_EMAIL}" --role=roles/compute.xpnAdmin --format=none
+gcloud resource-manager folders add-iam-policy-binding "${tb_folder_id}" --member=serviceAccount:"${SA_EMAIL}" --role=roles/logging.logWriter --format=none
+gcloud resource-manager folders add-iam-policy-binding "${tb_folder_id}" --member=serviceAccount:"${SA_EMAIL}" --role=roles/logging.configWriter --format=none
 
 # Add permissions at the billing level
 echo "Adding permissions at the billing account level..."

--- a/tb-marketplace/tb-config-creator/tb-config-creator
+++ b/tb-marketplace/tb-config-creator/tb-config-creator
@@ -213,6 +213,7 @@ gcloud projects add-iam-policy-binding "${PROJECT_ID}" --member=serviceAccount:"
 gcloud projects add-iam-policy-binding "${PROJECT_ID}" --member=serviceAccount:"${SA_EMAIL}" --role=roles/storage.admin --format=none
 gcloud projects add-iam-policy-binding "${PROJECT_ID}" --member=serviceAccount:"${SA_EMAIL}" --role=roles/source.admin --format=none
 gcloud projects add-iam-policy-binding "${PROJECT_ID}" --member=serviceAccount:"${SA_EMAIL}" --role=roles/logging.logWriter --format=none
+gcloud projects add-iam-policy-binding "${PROJECT_ID}" --member=serviceAccount:"${SA_EMAIL}" --role=roles/logging.configWriter --format=none
 
 # Add permissions at the folder level
 echo "Adding permissions at the folder level..."

--- a/tb-marketplace/tb-config-creator/tb-config-creator
+++ b/tb-marketplace/tb-config-creator/tb-config-creator
@@ -186,9 +186,7 @@ gcloud resource-manager folders get-iam-policy "${tb_folder_id}" > rootfolderiam
 sed -i "1 i\auditConfigs:" rootfolderiampolicy.yaml
 sed -i "2 i\- auditLogConfigs:" rootfolderiampolicy.yaml
 sed -i "3 i\  - logType: ADMIN_READ" rootfolderiampolicy.yaml
-sed -i "4 i\  - logType: DATA_WRITE" rootfolderiampolicy.yaml
-sed -i "5 i\  - logType: DATA_READ" rootfolderiampolicy.yaml
-sed -i "6 i\  service: allServices" rootfolderiampolicy.yaml
+sed -i "4 i\  service: allServices" rootfolderiampolicy.yaml
 gcloud resource-manager folders set-iam-policy "${tb_folder_id}" rootfolderiampolicy.yaml 
 rm rootfolderiampolicy.yaml
 


### PR DESCRIPTION
## PR Type  
What kind of change does this PR introduce?  
*Enables Admin read/write Audit Logging on the TB folder level and enables exporting of the logs to the Telemetry project*
  
Please check the boxes that applies to this PR.  
  
- [ ] Bugfix  
- [ X ] Feature  
- [ ] Code style update (formatting, local variables)  
- [ ] Refactoring (no functional changes, no api changes)  
- [ ] Build related changes  
- [ ] CI related changes  
- [ ] Documentation content changes  
- [ ] TranquilityBase application / infrastructure changes  
- [ ] Other... Please describe:  


## Purpose 
Full purpose found in ticket #299 

Notiable changes: Due to the TB development environment logging will be enabled at the folder level. This can later be moved to the organisation level with little refactoring if needed. 

To enable Audit logging for Admin read/write operations at the TB folder level and create a aggregated sink to export the logs to a storage bucket within the telemetry project. 


##Testing
Admin write log created: 
![adminlogfile](https://user-images.githubusercontent.com/66415638/86541611-2930e280-bf06-11ea-92e2-27e6fd6fa106.PNG)


Admin read log created
![datalogfile](https://user-images.githubusercontent.com/66415638/86541617-3057f080-bf06-11ea-9a3a-63dbb86fd9d4.PNG)


Log Sink:
![sink](https://user-images.githubusercontent.com/66415638/86541662-84fb6b80-bf06-11ea-8a20-dcb23e837c77.PNG)





  
## Reviewers  
 - **Reviewer A** please review this part.  
 - **Review B** please review this part.  
  
  ## Checklist  
 - [X ] This PR is linked to one or more issues.  
 - [X ] This PR has been tested (attach evidence if possible).  
 - [X ] This PR has passed style guidelines.  
