### PR TITLE
Issue 299

### DIFF
--- a/tb-gcp-tr/landingZone/no-itop/main.tf
+++ b/tb-gcp-tr/landingZone/no-itop/main.tf
@@ -128,7 +128,7 @@ module "shared-vpc" {
 ##### Audit logging #####
 
 module "audit-log-bucket" {
-  source = "github.com/tranquilitybase-io/terraform-google-cloud-storage.git//modules/simple_bucket?ref=logging"
+  source = "github.com/tranquilitybase-io/terraform-google-cloud-storage.git//modules/simple_bucket?ref=logging-v3"
 
   project_id      = module.shared_projects.shared_telemetry_id
   name            = "${var.tb_folder_admin_rw_audit_log_bucket_name}-${var.tb_discriminator}"
@@ -142,7 +142,7 @@ resource "google_logging_folder_sink" "audit-log-sink" {
   folder           = var.root_id
   name             = var.tb_folder_admin_rw_audit_log_sink_name
   destination      = "storage.googleapis.com/${module.audit-log-bucket.name}"
-  filter           = "logName:(/logs/cloudaudit.googleapis.com%2Factivity OR /logs/cloudaudit.googleapis.com%2Fdata_access OR /logs/cloudaudit.googleapis.com%2Fsystem_event)"
+  filter           = var.tb_folder_admin_rw_audit_log_bucket_filter
   include_children = var.include_children
 }
 

--- a/tb-gcp-tr/landingZone/no-itop/variables.tf
+++ b/tb-gcp-tr/landingZone/no-itop/variables.tf
@@ -434,14 +434,20 @@ variable "iam_members_bindings" {
 
 ### Audit Bucket ###
 
+variable "tb_folder_admin_rw_audit_log_bucket_filter" {
+  default     = "logName:(/logs/cloudaudit.googleapis.com%2Factivity OR /logs/cloudaudit.googleapis.com%2Fsystem_event)"
+  description = "TB folder admin read/write bucket audit logs filter"
+  type        = string
+}
+
 variable "tb_folder_admin_rw_audit_log_bucket_location" {
   description = "location for tb folder admin read/write bucket audit logs"
-  type        = "string"
+  type        = string
   default     = "europe-west2"
 }
 variable "tb_folder_admin_rw_audit_log_bucket_storage_class" {
   description = "storage class for tb folder admin read/write bucket audit logs"
-  type        = "string"
+  type        = string
   default     = "REGIONAL"
 }
 variable "tb_folder_admin_rw_audit_log_bucket_name" {
@@ -468,7 +474,7 @@ variable "tb_folder_admin_rw_audit_log_bucket_lifecycle_rules" {
     },
     {
       action = {
-        type = "Delete"
+        type          = "Delete"
         storage_class = ""
       },
       condition = {

--- a/tb-gcp-tr/landingZone/no-itop/variables.tf
+++ b/tb-gcp-tr/landingZone/no-itop/variables.tf
@@ -429,3 +429,64 @@ variable "iam_members_bindings" {
     member = "group:cloud-storage-analytics@google.com"
   }]
 }
+
+##### Audit logging #####
+
+### Audit Bucket ###
+
+variable "tb_folder_admin_rw_audit_log_bucket_location" {
+  description = "location for tb folder admin read/write bucket audit logs"
+  type        = "string"
+  default     = "europe-west2"
+}
+variable "tb_folder_admin_rw_audit_log_bucket_storage_class" {
+  description = "storage class for tb folder admin read/write bucket audit logs"
+  type        = "string"
+  default     = "REGIONAL"
+}
+variable "tb_folder_admin_rw_audit_log_bucket_name" {
+  description = "bucket name for tb folder admin read/write bucket audit logs"
+  type        = string
+  default     = "tb-folder-admin-rw-audit-logs"
+}
+variable "tb_folder_admin_rw_audit_log_bucket_labels" {
+  description = "labels for tb folder admin read/write bucket audit logs"
+  type        = map(string)
+  default     = { "function" = "bucket-to-store-root-folder-admin-rw-audit-logs" }
+}
+variable "tb_folder_admin_rw_audit_log_bucket_lifecycle_rules" {
+  description = "lifecycle rules for tb folder admin read/write bucket audit logs. Defaults to moving from standard to nearline after 30 days and deleting after 365."
+  default = [
+    {
+      action = {
+        type          = "SetStorageClass"
+        storage_class = "NEARLINE"
+      },
+      condition = {
+        age = "30"
+      }
+    },
+    {
+      action = {
+        type = "Delete"
+        storage_class = ""
+      },
+      condition = {
+        age = "365"
+      }
+    }
+  ]
+}
+
+### Audit Folder Log Sink Creator ###
+
+variable "tb_folder_admin_rw_audit_log_sink_name" {
+  description = "log sink name for tb folder admin read/write bucket audit logs"
+  default     = "tb-folder-admin-rw-audit-log-sink"
+  type        = string
+}
+variable "include_children" {
+  description = "include logs for folders and project below the tb folder"
+  default     = true
+  type        = bool
+}

--- a/tb-marketplace/tb-config-creator/tb-config-creator
+++ b/tb-marketplace/tb-config-creator/tb-config-creator
@@ -189,11 +189,22 @@ TBASE_FOLDER_NAME="${TBASE_FOLDER_PREFIX}${RND}"
 #Explicit labelling is required here because Terraform has not been applied.
 ACTIVE_ACCOUNT="$(gcloud config list account --format "value(core.account)" | cut -d@ -f1)"
 echo "Resources will be labelled with the owner: ${ACTIVE_ACCOUNT}"
-sed -i "s/created_by:.*/created_by: '${ACTIVE_ACCOUNT}'/" $(dirname ${BASH_SOURCE[0]})/../tb-dep-manager/test_config.yaml
+sed -i "s/created-by:.*/created-by: '${ACTIVE_ACCOUNT}'/" $(dirname ${BASH_SOURCE[0]})/../tb-dep-manager/test_config.yaml
 # Create Tbase folder to store bootstrap project, involves parsing the output of the glcoud command to get the folder id
 folder_id_entry=$(gcloud resource-manager folders create --display-name="${TBASE_FOLDER_NAME}" --"${parent_type}"="${parent_id}" --format="value(name)")
 IFS='/' read -ra split_array <<< "$folder_id_entry"
 tb_folder_id="$(echo ${split_array[1]} | sed 's/[^0-9]*//g')"
+
+#Add auditing to at folder level
+gcloud resource-manager folders get-iam-policy "${tb_folder_id}" > rootfolderiampolicy.yaml
+cat >> rootfolderiampolicy.yaml <<EOF
+auditConfigs:
+- auditLogConfigs:
+  - logType: ADMIN_READ
+  service: allServices
+EOF
+gcloud resource-manager folders set-iam-policy "${tb_folder_id}" rootfolderiampolicy.yaml
+rm rootfolderiampolicy.yaml
 
 echo "Creating project..."
 gcloud projects create "${PROJECT_ID}" --folder "${tb_folder_id}" --format=none --labels created_by="${ACTIVE_ACCOUNT}","${LABELS}"
@@ -226,6 +237,7 @@ gcloud resource-manager folders add-iam-policy-binding "${tb_folder_id}" --membe
 gcloud resource-manager folders add-iam-policy-binding "${tb_folder_id}" --member=serviceAccount:"${SA_EMAIL}" --role=roles/cloudkms.admin --format=none
 gcloud resource-manager folders add-iam-policy-binding "${tb_folder_id}" --member=serviceAccount:"${SA_EMAIL}" --role=roles/logging.logWriter --format=none
 gcloud resource-manager folders add-iam-policy-binding "${tb_folder_id}" --member=serviceAccount:"${SA_EMAIL}" --role=roles/logging.configWriter --format=none
+
 # Add permissions at the billing level
 echo "Adding permissions at the billing account level..."
 gcloud beta billing accounts get-iam-policy "${BILLING_ID}" > billing.yaml


### PR DESCRIPTION
## PR Type  
What kind of change does this PR introduce?  
  
Please check the boxes that applies to this PR.  
  
- [ ] Bugfix  
- [ X ] Feature  
- [ ] Code style update (formatting, local variables)  
- [ ] Refactoring (no functional changes, no api changes)  
- [ ] Build related changes  
- [ ] CI related changes  
- [ ] Documentation content changes  
- [ ] TranquilityBase application / infrastructure changes  
- [ ] Other... Please describe:  


## Purpose 
Full purpose found in ticket #299

Notiable changes: Due to the TB development environment logging will be enabled at the folder level. This can later be moved to the organisation level with little refactoring if needed.

To enable Audit logging for Admin read/write operations at the TB folder level and create a aggregated sink to export the logs to a storage bucket within the telemetry project.
  
## Testing

Admin Write Log:
![2](https://user-images.githubusercontent.com/66415638/90444712-4a284e00-e0d6-11ea-9a9f-f53857a7fd65.PNG)



Admin Read Log:
![1](https://user-images.githubusercontent.com/66415638/90444716-4d233e80-e0d6-11ea-8a14-0f9001b8a366.PNG)






## Reviewers  
 - **Reviewer A** please review this part.  
 - **Review B** please review this part.  
  
  ## Checklist  
 - [ X ] This PR is linked to one or more issues.  
 - [ X ] This PR has been tested (attach evidence if possible).  
 - [ X ] This PR has passed style guidelines.  
