### PR TITLE
Issue 55

### DIFF
--- a/tb-gcp-deploy/pack/packer-no-itop.json
+++ b/tb-gcp-deploy/pack/packer-no-itop.json
@@ -117,6 +117,11 @@
     },
     {
       "type": "file",
+      "source": "{{user `tb_repos_root_path`}}/tb-gcp-tr/kms",
+      "destination": "tb-gcp-tr/"
+    },
+    {
+      "type": "file",
       "source": "{{user `tb_repos_root_path`}}/tb-gcp-tr/.gitignore",
       "destination": "tb-gcp-tr/"
     },

--- a/tb-gcp-tr/apis-activation/main.tf
+++ b/tb-gcp-tr/apis-activation/main.tf
@@ -56,6 +56,8 @@ locals {
     "container.googleapis.com",
     "serviceusage.googleapis.com"
   ]
+  telemetry_project_apis = [
+    "cloudkms.googleapis.com"]
 }
 
 
@@ -79,6 +81,14 @@ resource "google_project_service" "eagle_console" {
 resource "google_project_service" "bastion" {
   project                    = var.bastion_project_id
   for_each                   = toset(local.bastion_project_apis)
+  service                    = each.value
+  disable_dependent_services = true
+  depends_on                 = [google_project_service.host-project]
+}
+
+resource "google_project_service" "telemetry" {
+  project                    = var.telemetry_project_id
+  for_each                   = toset(local.telemetry_project_apis)
   service                    = each.value
   disable_dependent_services = true
   depends_on                 = [google_project_service.host-project]

--- a/tb-gcp-tr/apis-activation/main.tf
+++ b/tb-gcp-tr/apis-activation/main.tf
@@ -57,7 +57,8 @@ locals {
     "serviceusage.googleapis.com"
   ]
   telemetry_project_apis = [
-    "cloudkms.googleapis.com"]
+    "cloudkms.googleapis.com"
+  ]
 }
 
 

--- a/tb-gcp-tr/apis-activation/main.tf
+++ b/tb-gcp-tr/apis-activation/main.tf
@@ -54,7 +54,7 @@ locals {
     "recommender.googleapis.com",
     "iap.googleapis.com",
     "container.googleapis.com",
-    "serviceusage.googleapis.com"
+    "serviceusage.googleapis.com",
   ]
   telemetry_project_apis = [
     "cloudkms.googleapis.com"

--- a/tb-gcp-tr/apis-activation/outputs.tf
+++ b/tb-gcp-tr/apis-activation/outputs.tf
@@ -16,6 +16,6 @@ output "all_apis_enabled" {
 
   value = join(",", [values(google_project_service.eagle_console)[0].project,
     values(google_project_service.bastion)[0].project,
-    values(google_project_service.telemetry)[0].project
+    values(google_project_service.telemetry)[0].project,
   ])
 }

--- a/tb-gcp-tr/apis-activation/outputs.tf
+++ b/tb-gcp-tr/apis-activation/outputs.tf
@@ -16,6 +16,6 @@ output "all_apis_enabled" {
 
   value = join(",", [values(google_project_service.eagle_console)[0].project,
     values(google_project_service.bastion)[0].project,
-
+    values(google_project_service.telemetry)[0].project
   ])
 }

--- a/tb-gcp-tr/apis-activation/variables.tf
+++ b/tb-gcp-tr/apis-activation/variables.tf
@@ -27,3 +27,8 @@ variable "bastion_project_id" {
   description = "id for the bastion project"
   type        = string
 }
+
+variable "telemetry_project_id" {
+  description = "id for the bastion project"
+  type        = string
+}

--- a/tb-gcp-tr/apis-activation/variables.tf
+++ b/tb-gcp-tr/apis-activation/variables.tf
@@ -29,6 +29,6 @@ variable "bastion_project_id" {
 }
 
 variable "telemetry_project_id" {
-  description = "id for the bastion project"
+  description = "id for the telemetry project"
   type        = string
 }

--- a/tb-gcp-tr/kms/main.tf
+++ b/tb-gcp-tr/kms/main.tf
@@ -1,17 +1,13 @@
-resource "random_id" "rannum" {
-  byte_length = var.random_num_len
-}
-
 #CREATE-KEY-RING-FOR-USE-WITH-BUCKETS
-resource "google_kms_key_ring" "bucketkeyring" {
-  name     = "terraform-key-ring-${random_id.rannum.hex}"
-  location = var.kms_ring_location
+resource "google_kms_key_ring" "bucket_key_ring" {
+  name     = var.kms_key_ring_name
+  location = var.kms_key_ring_location
 }
 
 #CREATE-CRYPTO-KEY-FOR-USE-WITH-BUCKETS
-resource "google_kms_crypto_key" "key" {
-  name = "terraform-key-ring-${random_id.rannum.hex}"
-  key_ring = google_kms_key_ring.bucketkeyring.self_link
+resource "google_kms_crypto_key" "bucket_key" {
+  name = var.kms_key_name
+  key_ring = google_kms_key_ring.bucket_key_ring.self_link
   rotation_period = var.kms_key_rotation_period
   purpose = var.kms_key_purpose
 

--- a/tb-gcp-tr/kms/main.tf
+++ b/tb-gcp-tr/kms/main.tf
@@ -1,5 +1,6 @@
 #CREATE-KEY-RING-FOR-USE-WITH-BUCKETS
 resource "google_kms_key_ring" "bucket_key_ring" {
+  project  = var.kms_key_ring_project_id
   name     = var.kms_key_ring_name
   location = var.kms_key_ring_location
 }

--- a/tb-gcp-tr/kms/main.tf
+++ b/tb-gcp-tr/kms/main.tf
@@ -1,0 +1,22 @@
+resource "random_id" "rannum" {
+  byte_length = var.random_num_len
+}
+
+#CREATE-KEY-RING-FOR-USE-WITH-BUCKETS
+resource "google_kms_key_ring" "bucketkeyring" {
+  name     = "terraform-key-ring-${random_id.rannum.hex}"
+  location = var.kms_ring_location
+}
+
+#CREATE-CRYPTO-KEY-FOR-USE-WITH-BUCKETS
+resource "google_kms_crypto_key" "key" {
+  name = "terraform-key-ring-${random_id.rannum.hex}"
+  key_ring = google_kms_key_ring.bucketkeyring.self_link
+  rotation_period = var.kms_key_rotation_period
+  purpose = var.kms_key_purpose
+
+  version_template {
+    algorithm = var.kms_key_algorithm
+    protection_level = var.kms_key_protection_level
+  }
+}

--- a/tb-gcp-tr/kms/main.tf
+++ b/tb-gcp-tr/kms/main.tf
@@ -1,8 +1,16 @@
+resource "null_resource" "api_enabled" {
+  triggers = {
+    dependency = var.apis_dependency
+  }
+}
+
 #CREATE-KEY-RING-FOR-USE-WITH-BUCKETS
 resource "google_kms_key_ring" "bucket_key_ring" {
   project  = var.kms_key_ring_project_id
   name     = var.kms_key_ring_name
   location = var.kms_key_ring_location
+
+  depends_on = [null_resource.api_enabled]
 }
 
 #CREATE-CRYPTO-KEY-FOR-USE-WITH-BUCKETS
@@ -16,4 +24,6 @@ resource "google_kms_crypto_key" "bucket_key" {
     algorithm = var.kms_key_algorithm
     protection_level = var.kms_key_protection_level
   }
+
+  depends_on = [null_resource.api_enabled]
 }

--- a/tb-gcp-tr/kms/variables.tf
+++ b/tb-gcp-tr/kms/variables.tf
@@ -1,24 +1,32 @@
 variable "kms_key_ring_project_id" {
   type = string
+  default = ""
 }
 variable "kms_key_ring_name" {
   type = string
+  default = ""
 }
 variable "kms_key_ring_location" {
   type = string
+  default = ""
 }
 variable "kms_key_name" {
   type = string
+  default = ""
 }
 variable "kms_key_rotation_period" {
   type = string
+  default = ""
 }
 variable "kms_key_purpose" {
   type = string
+  default = ""
 }
 variable "kms_key_algorithm" {
   type = string
+  default = ""
 }
 variable "kms_key_protection_level" {
   type = string
+  default = ""
 }

--- a/tb-gcp-tr/kms/variables.tf
+++ b/tb-gcp-tr/kms/variables.tf
@@ -1,5 +1,8 @@
-variable "kms_key_ring_name" {
+variable "kms_key_ring_project_id" {
   type = string
+}
+variable "kms_key_ring_name" {
+  type = stringd
 }
 variable "kms_key_ring_location" {
   type = string

--- a/tb-gcp-tr/kms/variables.tf
+++ b/tb-gcp-tr/kms/variables.tf
@@ -1,0 +1,18 @@
+variable "random_num_len" {
+  type = string
+}
+variable "kms_ring_location" {
+  type = string
+}
+variable "kms_key_rotation_period" {
+  type = string
+}
+variable "kms_key_purpose" {
+  type = string
+}
+variable "kms_key_algorithm" {
+  type = string
+}
+variable "kms_key_protection_level" {
+  type = string
+}

--- a/tb-gcp-tr/kms/variables.tf
+++ b/tb-gcp-tr/kms/variables.tf
@@ -2,7 +2,7 @@ variable "kms_key_ring_project_id" {
   type = string
 }
 variable "kms_key_ring_name" {
-  type = stringd
+  type = string
 }
 variable "kms_key_ring_location" {
   type = string

--- a/tb-gcp-tr/kms/variables.tf
+++ b/tb-gcp-tr/kms/variables.tf
@@ -1,7 +1,10 @@
-variable "random_num_len" {
+variable "kms_key_ring_name" {
   type = string
 }
-variable "kms_ring_location" {
+variable "kms_key_ring_location" {
+  type = string
+}
+variable "kms_key_name" {
   type = string
 }
 variable "kms_key_rotation_period" {

--- a/tb-gcp-tr/kms/variables.tf
+++ b/tb-gcp-tr/kms/variables.tf
@@ -1,3 +1,7 @@
+variable "apis_dependency" {
+  type        = string
+  description = "Creates dependency on apis-activation module"
+}
 variable "kms_key_ring_project_id" {
   type = string
   default = ""

--- a/tb-gcp-tr/landingZone/no-itop/main.tf
+++ b/tb-gcp-tr/landingZone/no-itop/main.tf
@@ -83,8 +83,9 @@ module "apis_activation" {
 module "bucket_kms_key" {
   source = "../../kms"
 
-  random_num_len           = var.random_num_len
-  kms_ring_location        = var.kms_ring_location
+  kms_key_ring_name        = var.kms_key_ring_name
+  kms_key_ring_location    = var.kms_key_ring_location
+  kms_key_name             = var.kms_key_name
   kms_key_rotation_period  = var.kms_key_rotation_period
   kms_key_purpose          = var.kms_key_purpose
   kms_key_algorithm        = var.kms_key_algorithm

--- a/tb-gcp-tr/landingZone/no-itop/main.tf
+++ b/tb-gcp-tr/landingZone/no-itop/main.tf
@@ -83,6 +83,8 @@ module "apis_activation" {
 
 module "bucket_kms_key" {
   source = "../../kms"
+
+  apis_dependency          = module.apis_activation.all_apis_enabled
   kms_key_ring_project_id  = module.shared_projects.shared_telemetry_id
   kms_key_ring_name        = var.kms_key_ring_name
   kms_key_ring_location    = var.kms_key_ring_location

--- a/tb-gcp-tr/landingZone/no-itop/main.tf
+++ b/tb-gcp-tr/landingZone/no-itop/main.tf
@@ -80,6 +80,17 @@ module "apis_activation" {
   eagle_console_project_id = module.shared_projects.shared_ec_id
 }
 
+module "bucket_kms_key" {
+  source = "../../kms"
+
+  random_num_len           = var.random_num_len
+  kms_ring_location        = var.kms_ring_location
+  kms_key_rotation_period  = var.kms_key_rotation_period
+  kms_key_purpose          = var.kms_key_purpose
+  kms_key_algorithm        = var.kms_key_algorithm
+  kms_key_protection_level = var.kms_key_protection_level
+}
+
 module "shared-vpc" {
   source = "../../shared-vpc"
 

--- a/tb-gcp-tr/landingZone/no-itop/main.tf
+++ b/tb-gcp-tr/landingZone/no-itop/main.tf
@@ -82,7 +82,7 @@ module "apis_activation" {
 
 module "bucket_kms_key" {
   source = "../../kms"
-  kms_key_ring_project_id     = module.shared_projects.shared_telemetry_id
+  kms_key_ring_project_id  = module.shared_projects.shared_telemetry_id
   kms_key_ring_name        = var.kms_key_ring_name
   kms_key_ring_location    = var.kms_key_ring_location
   kms_key_name             = var.kms_key_name

--- a/tb-gcp-tr/landingZone/no-itop/main.tf
+++ b/tb-gcp-tr/landingZone/no-itop/main.tf
@@ -82,7 +82,7 @@ module "apis_activation" {
 
 module "bucket_kms_key" {
   source = "../../kms"
-
+  kms_key_ring_project_id     = module.shared_projects.shared_telemetry_id
   kms_key_ring_name        = var.kms_key_ring_name
   kms_key_ring_location    = var.kms_key_ring_location
   kms_key_name             = var.kms_key_name

--- a/tb-gcp-tr/landingZone/no-itop/main.tf
+++ b/tb-gcp-tr/landingZone/no-itop/main.tf
@@ -78,6 +78,7 @@ module "apis_activation" {
   bastion_project_id       = module.shared_projects.shared_bastion_id
   host_project_id          = module.shared_projects.shared_networking_id
   eagle_console_project_id = module.shared_projects.shared_ec_id
+  telemetry_project_id     = module.shared_projects.shared_telemetry_id
 }
 
 module "bucket_kms_key" {

--- a/tb-gcp-tr/landingZone/no-itop/variables.tf
+++ b/tb-gcp-tr/landingZone/no-itop/variables.tf
@@ -396,4 +396,5 @@ variable "kms_key_algorithm" {
 }
 variable "kms_key_protection_level" {
   type = string
+  default = "SOFTWARE"
 }

--- a/tb-gcp-tr/landingZone/no-itop/variables.tf
+++ b/tb-gcp-tr/landingZone/no-itop/variables.tf
@@ -364,3 +364,28 @@ variable "sharedservice_jenkinsmaster_yaml_path" {
   description = "Path to the yaml file to deploy Jenkins on the shared gke-ec cluster"
   type        = string
 }
+
+### Bucket KMS Key ###
+variable "random_num_len" {
+  type = string
+  default = "6"
+}
+variable "kms_ring_location" {
+  type = string
+  default = "europe"
+}
+variable "kms_key_rotation_period" {
+  type = string
+  default = "2592000s" #1 month
+}
+variable "kms_key_purpose" {
+  type = string
+  default = "ENCRYPT_DECRYPT" #symmetric key
+}
+variable "kms_key_algorithm" {
+  type = string
+  default = "GOOGLE_SYMMETRIC_ENCRYPTION" #uses AES256
+}
+variable "kms_key_protection_level" {
+  type = string
+}

--- a/tb-gcp-tr/landingZone/no-itop/variables.tf
+++ b/tb-gcp-tr/landingZone/no-itop/variables.tf
@@ -376,7 +376,7 @@ variable "kms_key_ring_name" {
 }
 variable "kms_key_ring_location" {
   type = string
-  default = "europe"
+  default = "us"
 }
 variable "kms_key_name" {
   type = string

--- a/tb-gcp-tr/landingZone/no-itop/variables.tf
+++ b/tb-gcp-tr/landingZone/no-itop/variables.tf
@@ -366,6 +366,9 @@ variable "sharedservice_jenkinsmaster_yaml_path" {
 }
 
 ### Bucket KMS Key ###
+variable "kms_key_ring_project_id" {
+  type = string
+}
 variable "kms_key_ring_name" {
   type = string
   default = "tf-state-bucket-keyring"

--- a/tb-gcp-tr/landingZone/no-itop/variables.tf
+++ b/tb-gcp-tr/landingZone/no-itop/variables.tf
@@ -368,6 +368,7 @@ variable "sharedservice_jenkinsmaster_yaml_path" {
 ### Bucket KMS Key ###
 variable "kms_key_ring_project_id" {
   type = string
+  default = ""
 }
 variable "kms_key_ring_name" {
   type = string

--- a/tb-gcp-tr/landingZone/no-itop/variables.tf
+++ b/tb-gcp-tr/landingZone/no-itop/variables.tf
@@ -366,13 +366,17 @@ variable "sharedservice_jenkinsmaster_yaml_path" {
 }
 
 ### Bucket KMS Key ###
-variable "random_num_len" {
+variable "kms_key_ring_name" {
   type = string
-  default = "6"
+  default = "tf-state-bucket-keyring"
 }
-variable "kms_ring_location" {
+variable "kms_key_ring_location" {
   type = string
   default = "europe"
+}
+variable "kms_key_name" {
+  type = string
+  default = "tf-state-bucket-key"
 }
 variable "kms_key_rotation_period" {
   type = string

--- a/tb-gcp-tr/landingZone/tb-welcome
+++ b/tb-gcp-tr/landingZone/tb-welcome
@@ -104,7 +104,7 @@ done
 sudo gsutil versioning set on "gs://${terraform_state_bucket_name}/"
 
 # Encrypt TF state bucket using CMEK
-sudo gsutil kms encryption -k projects/"${PROJECT_ID}"/locations/europe/keyRings/tf-state-bucket-keyring/cryptoKeys/tf-state-bucket-key gs://"${terraform_state_bucket_name}"
+sudo gsutil kms encryption -p ${PROJECT_ID} -k projects/"shared-telemetry-${tb_discriminator}"/locations/us/keyRings/tf-state-bucket-keyring/cryptoKeys/tf-state-bucket-key "gs://${terraform_state_bucket_name}"
 
 # Commit current TB terraform code to GCR
 cd /tmp

--- a/tb-gcp-tr/landingZone/tb-welcome
+++ b/tb-gcp-tr/landingZone/tb-welcome
@@ -103,6 +103,9 @@ done
 # Set versioning on for tf state bucket.
 sudo gsutil versioning set on "gs://${terraform_state_bucket_name}/"
 
+# Encrypt TF state bucket using CMEK
+sudo gsutil kms encryption -k projects/"${PROJECT_ID}"/locations/europe/keyRings/tf-state-bucket-keyring/cryptoKeys/tf-state-bucket-key gs://"${terraform_state_bucket_name}"
+
 # Commit current TB terraform code to GCR
 cd /tmp
 # Check for repo existence

--- a/tb-marketplace/tb-config-creator/tb-config-creator
+++ b/tb-marketplace/tb-config-creator/tb-config-creator
@@ -212,6 +212,8 @@ gcloud resource-manager folders add-iam-policy-binding "${tb_folder_id}" --membe
 gcloud resource-manager folders add-iam-policy-binding "${tb_folder_id}" --member=serviceAccount:"${SA_EMAIL}" --role=roles/billing.projectManager --format=none
 gcloud resource-manager folders add-iam-policy-binding "${tb_folder_id}" --member=serviceAccount:"${SA_EMAIL}" --role=roles/compute.networkAdmin --format=none
 gcloud resource-manager folders add-iam-policy-binding "${tb_folder_id}" --member=serviceAccount:"${SA_EMAIL}" --role=roles/compute.xpnAdmin --format=none
+gcloud resource-manager folders add-iam-policy-binding "${tb_folder_id}" --member=serviceAccount:"${SA_EMAIL}" --role=roles/cloudkms.admin --format=none
+
 
 # Add permissions at the billing level
 echo "Adding permissions at the billing account level..."


### PR DESCRIPTION
## PR Type  
Ready for review and merge
  
- [ ] Bugfix  
- [ X ] Feature  
- [ ] Code style update (formatting, local variables)  
- [ ] Refactoring (no functional changes, no api changes)  
- [ ] Build related changes  
- [ ] CI related changes  
- [ ] Documentation content changes  
- [ ] TranquilityBase application / infrastructure changes  
- [ ] Other... Please describe:  


## Purpose 
Full purpose found in ticket #55 

The purpose of this ticket was to enable CMEK on all buckets. Currently there is only one bucket (TF state bucket). 

CMEK has been enabled on this TF state bucket using the code provided in this PR.
All other future buckets will have CMEK enabled on creation using the bucket module in #355 
This bucket module in #355 can not be used to create the TF state bucket due to needing a bucket before any terraform runs so the following code in this PR enables CMEK on the bucket using gcloud commands. 

The key is rotated every 30 days, has "SOFTWARE" level protection and uses Googles "GOOGLE_SYSMETRIC_ENCRYPTION" which uses AES256


## Testing
Deployment:
![sucess](https://user-images.githubusercontent.com/66415638/87326296-74f91280-c52a-11ea-8363-cab2ccc0eae0.PNG)

TF state bucket with CMEK:
![bucket](https://user-images.githubusercontent.com/66415638/87326367-8c380000-c52a-11ea-9304-76759d70a535.PNG)

KeyRing Created:
![keyring](https://user-images.githubusercontent.com/66415638/87326397-93f7a480-c52a-11ea-9343-ff9726fd765e.PNG)

Key created:
![key](https://user-images.githubusercontent.com/66415638/87326411-98bc5880-c52a-11ea-83a8-f6fcf1dd8795.PNG)


## Reviewers  
 - **Reviewer A** please review this part.  
 - **Review B** please review this part.  
  
  ## Checklist  
 - [ X ] This PR is linked to one or more issues.  
 - [ X ] This PR has been tested (attach evidence if possible).  
 - [ X ] This PR has passed style guidelines.  
