### PR TITLE
Issue 414

### DIFF
--- a/tb-ec-gcp/tf_create_subnets/main.tf
+++ b/tb-ec-gcp/tf_create_subnets/main.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 provider "google" {
-  version = "~> 2.5"
+  version = "~> 3.3"
   project = var.shared_networking_id
   region  = var.region
 }

--- a/tb-gcp-activator/main.tf
+++ b/tb-gcp-activator/main.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 provider "google" {
-  version = "~> 2.5"
+  version = "~> 3.3"
   region  = var.region
 }
 
@@ -22,7 +22,7 @@ provider "google-beta" {
   region  = var.region
   zone    = var.zone
   project = var.shared_vpc_host_project
-  version = "~> 2.5"
+  version = "~> 3.3"
   //project = "${google_project.activator.id}"
 }
 

--- a/tb-gcp-deploy/test/main.tf
+++ b/tb-gcp-deploy/test/main.tf
@@ -15,7 +15,7 @@
 provider "google" {
   region  = var.region
   zone    = var.zone
-  version = "~> 2.5"
+  version = "~> 3.3"
 }
 
 

--- a/tb-gcp-tr/bootstrap/main.tf
+++ b/tb-gcp-tr/bootstrap/main.tf
@@ -15,7 +15,7 @@
 provider "google" {
   region  = var.region
   zone    = var.region_zone
-  version = "~> 2.5"
+  version = "~> 3.3"
 }
 
 #CREATE-BOOTSTRAP-PROJECT

--- a/tb-gcp-tr/folder-structure-creation/examples/advanced/providers.tf
+++ b/tb-gcp-tr/folder-structure-creation/examples/advanced/providers.tf
@@ -15,6 +15,6 @@
 provider "google" {
   region  = var.region
   zone    = var.region_zone
-  version = "~> 2.5"
+  version = "~> 3.3"
 }
 

--- a/tb-gcp-tr/folder-structure-creation/examples/simple/providers.tf
+++ b/tb-gcp-tr/folder-structure-creation/examples/simple/providers.tf
@@ -15,6 +15,6 @@
 provider "google" {
   region  = var.region
   zone    = var.region_zone
-  version = "~> 2.5"
+  version = "~> 3.3"
 }
 

--- a/tb-gcp-tr/itop/examples/simple/provider.tf
+++ b/tb-gcp-tr/itop/examples/simple/provider.tf
@@ -16,7 +16,7 @@ provider "google" {
   project = var.host_project_id
   region  = var.region
   zone    = var.region_zone
-  version = "~> 2.5"
+  version = "~> 3.3"
 }
 
 provider "kubernetes" {

--- a/tb-gcp-tr/itop/examples/simple/provider.tf
+++ b/tb-gcp-tr/itop/examples/simple/provider.tf
@@ -21,6 +21,6 @@ provider "google" {
 
 provider "kubernetes" {
   config_context_cluster = "gke_${var.host_project_id}_${var.region_zone}_${var.k8_cluster_name}"
-  version                = "~> 1.10.0"
+  version                = "~> 1.11"
 }
 

--- a/tb-gcp-tr/kubernetes-cluster-creation/iam.tf
+++ b/tb-gcp-tr/kubernetes-cluster-creation/iam.tf
@@ -14,12 +14,12 @@
 
 # separate google-beta provider needed to assign sharedvpc networkUser permissions
 provider "google" {
-  version = "~> 2.5"
+  version = "~> 3.3"
 }
 
 provider "google-beta" {
   alias   = "shared-vpc"
-  version = "~> 2.5"
+  version = "~> 3.3"
 }
 
 # create compute service account for kubernetes cluster

--- a/tb-gcp-tr/landingZone/no-itop/input.tfvars
+++ b/tb-gcp-tr/landingZone/no-itop/input.tfvars
@@ -24,8 +24,8 @@ shared_bastion_project_name    = "shared-bastion"
 service_projects_number = "2"
 
 #SHARED VPC
-shared_vpc_name          = "shared-network"
-enable_flow_logs         = "false"
+shared_vpc_name  = "shared-network"
+enable_flow_logs = "false"
 gke_pod_network_name     = "gke-pods-snet"
 gke_service_network_name = "gke-services-snet"
 

--- a/tb-gcp-tr/landingZone/no-itop/main.tf
+++ b/tb-gcp-tr/landingZone/no-itop/main.tf
@@ -39,7 +39,7 @@ provider "google-beta" {
 
 provider "kubernetes" {
   alias   = "k8s"
-  version = "~> 1.10.0"
+  version = "~> 1.11"
 }
 
 terraform {

--- a/tb-gcp-tr/landingZone/no-itop/main.tf
+++ b/tb-gcp-tr/landingZone/no-itop/main.tf
@@ -19,14 +19,14 @@
 provider "google" {
   region  = var.region
   zone    = var.region_zone
-  version = "~> 2.5"
+  version = "~> 3.3"
 }
 
 provider "google" {
   alias   = "vault"
   region  = var.region
   zone    = var.region_zone
-  version = "~> 2.5"
+  version = "~> 3.3"
 }
 
 provider "google-beta" {
@@ -34,7 +34,7 @@ provider "google-beta" {
   region  = var.region
   zone    = var.region_zone
   project = module.shared_projects.shared_networking_id
-  version = "~> 2.5"
+  version = "~> 3.3"
 }
 
 provider "kubernetes" {
@@ -73,17 +73,8 @@ module "shared_projects" {
   shared_bastion_project_name    = var.shared_bastion_project_name
 }
 
-module "gcs_bucket_logging" {
-  source = "github.com/tranquilitybase-io/terraform-google-cloud-storage.git//modules/simple_bucket?ref=v1.6.0-logging"
-
-  name        = "${var.gcs_logs_bucket_prefix}-${var.tb_discriminator}"
-  project_id  = module.shared_projects.shared_telemetry_id
-  iam_members = var.iam_members_bindings
-  location    = var.region
-}
-
 module "apis_activation" {
-  source                   = "../../apis-activation"
+  source = "../../apis-activation"
   bastion_project_id       = module.shared_projects.shared_bastion_id
   host_project_id          = module.shared_projects.shared_networking_id
   eagle_console_project_id = module.shared_projects.shared_ec_id
@@ -156,7 +147,7 @@ module "gke-ec" {
       ),
     ],
   )
-  cluster_min_master_version        = var.cluster_ec_min_master_version
+  cluster_min_master_version = var.cluster_ec_min_master_version
   cluster_default_max_pods_per_node = var.cluster_ec_default_max_pods_per_node
 
   apis_dependency          = module.apis_activation.all_apis_enabled

--- a/tb-gcp-tr/landingZone/no-itop/variables.tf
+++ b/tb-gcp-tr/landingZone/no-itop/variables.tf
@@ -364,22 +364,3 @@ variable "sharedservice_jenkinsmaster_yaml_path" {
   description = "Path to the yaml file to deploy Jenkins on the shared gke-ec cluster"
   type        = string
 }
-
-#GCS bucket logging
-variable "gcs_logs_bucket_prefix" {
-  description = "Prefix of the access logs & storage logs storage bucket"
-  type        = string
-  default     = "tb-bucket-access-storage-logs"
-}
-
-variable "iam_members_bindings" {
-  description = "The list of IAM members to grant permissions for the logs bucket"
-  type = list(object({
-    role   = string,
-    member = string
-  }))
-  default = [{
-    role   = "roles/storage.legacyBucketWriter",
-    member = "group:cloud-storage-analytics@google.com"
-  }]
-}

--- a/tb-gcp-tr/shared-bastion/main.tf
+++ b/tb-gcp-tr/shared-bastion/main.tf
@@ -96,7 +96,7 @@ data "google_compute_image" "debian_image" {
 }
 
 data "google_compute_image" "centos_image" {
-  family  = "centos-7"
+  family = "centos-7"
   project = "centos-cloud"
 }
 
@@ -204,8 +204,8 @@ resource "google_compute_instance_group_manager" "windows_bastion_group" {
 
 //Create instance template for the Squid Proxy instance
 resource "google_compute_instance_template" "squid_proxy_template" {
-  project = var.shared_bastion_id
-  name    = "tb-kube-proxy-template"
+  project      = var.shared_bastion_id
+  name         = "tb-kube-proxy-template"
 
   machine_type = "n1-standard-2"
 
@@ -228,7 +228,7 @@ resource "google_compute_instance_template" "squid_proxy_template" {
     scopes = var.scopes
   }
 
-  metadata_startup_script = file("${path.module}/squid_startup.sh")
+    metadata_startup_script = file("${path.module}/squid_startup.sh")
 
 }
 

--- a/tb-gcp-tr/shared-vpc/examples/advanced/providers.tf
+++ b/tb-gcp-tr/shared-vpc/examples/advanced/providers.tf
@@ -15,6 +15,6 @@
 provider "google" {
   region  = var.region
   zone    = var.region_zone
-  version = "~> 2.5"
+  version = "~> 3.3"
 }
 

--- a/tb-gcp-tr/shared-vpc/examples/simple/providers.tf
+++ b/tb-gcp-tr/shared-vpc/examples/simple/providers.tf
@@ -15,6 +15,6 @@
 provider "google" {
   region  = var.region
   zone    = var.region_zone
-  version = "~> 2.5"
+  version = "~> 3.3"
 }
 

--- a/tb-gcp-tr/shared-vpc/main.tf
+++ b/tb-gcp-tr/shared-vpc/main.tf
@@ -32,13 +32,13 @@ resource "google_compute_network" "shared_network" {
 }
 
 resource "google_compute_subnetwork" "standard" {
-  count                    = length(var.standard_network_subnets)
-  name                     = var.standard_network_subnets[count.index]["name"]
-  ip_cidr_range            = var.standard_network_subnets[count.index]["cidr"]
-  region                   = var.region
+  count         = length(var.standard_network_subnets)
+  name          = var.standard_network_subnets[count.index]["name"]
+  ip_cidr_range = var.standard_network_subnets[count.index]["cidr"]
+  region        = var.region
   private_ip_google_access = true
-  project                  = var.host_project_id
-  network                  = google_compute_network.shared_network.name
+  project       = var.host_project_id
+  network       = google_compute_network.shared_network.name
 
   log_config {
     aggregation_interval = "INTERVAL_5_SEC"

--- a/tb-gcp-tr/single-bastion/providers.tf
+++ b/tb-gcp-tr/single-bastion/providers.tf
@@ -25,7 +25,7 @@ provider "google" {
   project     = var.bastion_project_id
   region      = var.region
   credentials = file(var.credentials_file)
-  version     = "~> 2.5"
+  version     = "~> 3.3"
 }
 
 # separate provider needed for creation of firewall rules in sharedvpc project
@@ -34,6 +34,6 @@ provider "google" {
   project     = var.sharedvpc_project_id
   region      = var.region
   credentials = file(var.credentials_file)
-  version     = "~> 2.5"
+  version     = "~> 3.3"
 }
 

--- a/tb-oss/source/.gitattributes
+++ b/tb-oss/source/.gitattributes
@@ -1,0 +1,1 @@
+hashicorp.terraform.zip filter=lfs diff=lfs merge=lfs -text

--- a/tb-oss/source/hashicorp.terraform.zip
+++ b/tb-oss/source/hashicorp.terraform.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:872245d9c6302b24dc0d98a1e010aef1e4ef60865a2d1f60102c8ad03e9d5a1d
+size 28424050

--- a/tb-oss/source/hashicorp.terraform.zip
+++ b/tb-oss/source/hashicorp.terraform.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5679c8d67a98b2919800abb09134614ae7d3a21f5878f5a068d0b41898b64a55
-size 189486374


### PR DESCRIPTION
## PR Type  
What kind of change does this PR introduce?  
This PR updates the Google and Kubernetes provider settings to use the latest version. Also updates the Terraform binary file used to Terraform 0.12.29.

This PR must ONLY be approved in conjunction with the PR for issue-415. This is because after updating to the latest provider settings, a number of issues arise which prevents TB from being deployed. Issue-415 highlights the issues that arise from updating to the latest provider settings and fixes them, therefore both issues go hand in hand.
  
Please check the boxes that applies to this PR.  
  
- [ ] Other... Please describe:  
Provider settings update


## Purpose 

Areas of the code where the Google provider version being used was 2.5 has now been updated to 3.3.
Areas of the code where the Kubernetes provider version being used was 1.10 has now been updated to 1.11.
Terraform 0.12.29 binary file has also been uploaded in the tb-oss directory using git LFS.
  
## Reviewers  
 - **Reviewer A** please review this part.  
 - **Review B** please review this part.  
  
  ## Checklist  
This PR is linked to issue-415.
