### PR TITLE
Issue 381

### DIFF
--- a/tb-gcp-tr/landingZone/istio-grafana_new.yaml
+++ b/tb-gcp-tr/landingZone/istio-grafana_new.yaml
@@ -30,7 +30,7 @@ spec:
         prefix: /
     route:
     - destination:
-        host: grafana
+        host: grafana.istio-system.svc.cluster.local
         port:
           number: 3000
     rewrite:
@@ -42,7 +42,7 @@ metadata:
   name: grafana
   namespace: istio-system
 spec:
-  host: grafana
+  host: grafana.istio-system.svc.cluster.local
   trafficPolicy:
     tls:
       mode: DISABLE

--- a/tb-gcp-tr/landingZone/istio-kiali_new.yaml
+++ b/tb-gcp-tr/landingZone/istio-kiali_new.yaml
@@ -30,7 +30,7 @@ spec:
         prefix: /kiali
     route:
     - destination:
-        host: kiali
+        host: kiali.istio-system.svc.cluster.local
         port:
           number: 20001
 ---
@@ -40,7 +40,7 @@ metadata:
   name: kiali
   namespace: istio-system
 spec:
-  host: kiali
+  host: kiali.istio-system.svc.cluster.local
   trafficPolicy:
     tls:
       mode: DISABLE

--- a/tb-gcp-tr/landingZone/no-itop/ec-configuration-file.tf
+++ b/tb-gcp-tr/landingZone/no-itop/ec-configuration-file.tf
@@ -23,7 +23,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: ec-config
-  namespace: default
+  namespace: ssp
 data:
   ec-config.yaml: |
     activator_folder_id: ${module.folder_structure.activators_id}

--- a/tb-gcp-tr/landingZone/no-itop/input.tfvars
+++ b/tb-gcp-tr/landingZone/no-itop/input.tfvars
@@ -54,7 +54,7 @@ cluster_opt_enable_private_nodes    = "true"
 cluster_opt_enable_private_endpoint = false
 
 #EC Deployment
-eagle_console_yaml_path = "/opt/tb/repo/tb-gcp-tr/landingZone/eagle_console.yaml"
+eagle_console_yaml_path = "/opt/tb/repo/tb-gcp-tr/shared-dac/eagle_console.yaml"
 ec_ui_source_bucket     = "tranquility-base-ui"
 ec_iam_service_account_roles = [
   "roles/resourcemanager.folderAdmin",

--- a/tb-gcp-tr/landingZone/no-itop/main.tf
+++ b/tb-gcp-tr/landingZone/no-itop/main.tf
@@ -200,17 +200,19 @@ module "SharedServices_namespace_creation" {
   dependency_var    = module.k8s-ec_context.k8s-context_id
 }
 
+## Creates service account for eagle console in the ssp namespace ##
+
 resource "null_resource" "kubernetes_service_account_key_secret" {
   triggers = {
     content = module.SharedServices_namespace_creation.id
   }
 
   provisioner "local-exec" {
-    command = "echo 'kubectl --context=${module.k8s-ec_context.context_name} create secret generic ec-service-account --from-file=${local_file.ec_service_account_key.filename}' | tee -a /opt/tb/repo/tb-gcp-tr/landingZone/kube.sh"
+    command = "echo 'kubectl --context=${module.k8s-ec_context.context_name} create secret generic ec-service-account -n ssp --from-file=${local_file.ec_service_account_key.filename}' | tee -a /opt/tb/repo/tb-gcp-tr/landingZone/kube.sh"
   }
 
   provisioner "local-exec" {
-    command = "echo 'kubectl --context=${module.k8s-ec_context.context_name} delete secret ec-service-account' | tee -a /opt/tb/repo/tb-gcp-tr/landingZone/kube.sh"
+    command = "echo 'kubectl --context=${module.k8s-ec_context.context_name} delete secret ec-service-account' -n ssp | tee -a /opt/tb/repo/tb-gcp-tr/landingZone/kube.sh"
     when    = destroy
   }
 }

--- a/tb-gcp-tr/shared-dac/eagle_console.yaml
+++ b/tb-gcp-tr/shared-dac/eagle_console.yaml
@@ -35,6 +35,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: houstonservice
+  namespace: ssp
   labels:
     app: houstonservice
 spec:
@@ -52,6 +53,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: gcpdac
+  namespace: ssp
 spec:
   ports:
     - port: 80
@@ -67,6 +69,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: mysql57
+  namespace: ssp
 spec:
   ports:
     - port: 3306
@@ -78,6 +81,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: redis
+  namespace: ssp
 spec:
   ports:
     - port: 6379
@@ -116,6 +120,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: houstonservice-v1
+  namespace: ssp
 spec:
   replicas: 1
   selector:
@@ -152,6 +157,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: redis-v1
+  namespace: ssp
 spec:
   replicas: 1
   selector:
@@ -171,6 +177,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: gcpdac-v1
+  namespace: ssp
 spec:
   replicas: 1
   selector:
@@ -248,6 +255,7 @@ apiVersion: apps/v1 # for versions before 1.9.0 use apps/v1beta2
 kind: Deployment
 metadata:
   name: mysql57
+  namespace: ssp
 spec:
   replicas: 1
   selector:
@@ -286,6 +294,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
   name: mygateway
+  namespace: ssp
 spec:
   selector:
     istio: private-ingressgateway # use istio default controller
@@ -304,6 +313,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
   name: houstonservice
+  namespace: ssp
 spec:
   hosts:
     - "*"
@@ -335,6 +345,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
   name: gcpdac
+  namespace: ssp
 spec:
   hosts:
     - "*"
@@ -384,6 +395,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
   name: redis
+  namespace: ssp
 spec:
   hosts:
     - "*"
@@ -415,6 +427,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
   name: houstonservice
+  namespace: ssp
   annotations:
     cloud.google.com/load-balancer-type: "Internal"
 spec:
@@ -427,6 +440,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
   name: gcpdac
+  namespace: ssp
   annotations:
     cloud.google.com/load-balancer-type: "Internal"
 spec:
@@ -439,6 +453,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
   name: redis
+  namespace: ssp
   annotations:
     cloud.google.com/load-balancer-type: "Internal"
 spec:

--- a/tb-gcp-tr/shared-dac/eagle_console.yaml
+++ b/tb-gcp-tr/shared-dac/eagle_console.yaml
@@ -16,6 +16,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: eagleconsole
+  namespace: ssp
   labels:
     app: eagleconsole
 spec:
@@ -88,6 +89,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: eagleconsole-v1
+  namespace: ssp
 spec:
   replicas: 1
   selector:
@@ -364,6 +366,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
   name: eagleconsole
+  namespace: ssp
 spec:
   hosts:
     - "*"
@@ -398,6 +401,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
   name: eagleconsole
+  namespace: ssp
   annotations:
     cloud.google.com/load-balancer-type: "Internal"
 spec:

--- a/tb-gcp-tr/shared-dac/eagle_console.yaml
+++ b/tb-gcp-tr/shared-dac/eagle_console.yaml
@@ -325,7 +325,7 @@ spec:
             prefix: /api
       route:
         - destination:
-            host: houstonservice
+            host: houstonservice.ssp.svc.cluster.local
             port:
               number: 80
       corsPolicy:
@@ -357,7 +357,7 @@ spec:
             prefix: /dac
       route:
         - destination:
-            host: gcpdac
+            host: gcpdac.ssp.svc.cluster.local
             port:
               number: 80
       corsPolicy:
@@ -386,7 +386,7 @@ spec:
   http:
     - route:
         - destination:
-            host: eagleconsole
+            host: eagleconsole.ssp.svc.cluster.local
             port:
               number: 443
 
@@ -404,7 +404,7 @@ spec:
   http:
     - route:
         - destination:
-            host: redis
+            host: redis.ssp.svc.cluster.local
             port:
               number: 6379
 
@@ -417,7 +417,7 @@ metadata:
   annotations:
     cloud.google.com/load-balancer-type: "Internal"
 spec:
-  host: eagleconsole
+  host: eagleconsole.ssp.svc.cluster.local
   trafficPolicy:
     loadBalancer:
       simple: LEAST_CONN
@@ -431,7 +431,7 @@ metadata:
   annotations:
     cloud.google.com/load-balancer-type: "Internal"
 spec:
-  host: houstonservice
+  host: houstonservice.ssp.svc.cluster.local
   trafficPolicy:
     loadBalancer:
       simple: LEAST_CONN
@@ -444,7 +444,7 @@ metadata:
   annotations:
     cloud.google.com/load-balancer-type: "Internal"
 spec:
-  host: gcpdac
+  host: gcpdac.ssp.svc.cluster.local
   trafficPolicy:
     loadBalancer:
       simple: LEAST_CONN
@@ -457,7 +457,7 @@ metadata:
   annotations:
     cloud.google.com/load-balancer-type: "Internal"
 spec:
-  host: redis
+  host: redis.ssp.svc.cluster.local
   trafficPolicy:
     loadBalancer:
       simple: LEAST_CONN


### PR DESCRIPTION
## PR Type  
What kind of change does this PR introduce?  
This PR moves the eagle console, houston service and dac related resources from the default namespace to the ssp namespace.

Also moves the eagle_console.yaml to the shared-dac folder.

The change in path is reflected in the tb-gcp-tr/landingzone/no-itop/input.tfvars file.

Also updates to use fully qualified domain names over short names when referencing different services.  

Please check the boxes that applies to this PR.  
  
- [ ] Namespace updates  



## Purpose 
https://github.com/tranquilitybase-io/tb-gcp/issues/381
   
Added namespace key value pair to metadata argument section.

Used fully qualified domain names over short names. For example referencing services in the form:
Service Name.Namespace Name.svc.cluster.local
  
## Reviewers  

  
  ## Checklist  
 - [ ] This PR is linked to one or more issues.  
 - [ ] This PR has been tested (attach evidence if possible).  
 - [ ] This PR has passed style guidelines.  
