### PR TITLE
Issue 441

### DIFF
--- a/tb-gcp-tr/shared-dac/jenkins-master.yaml
+++ b/tb-gcp-tr/shared-dac/jenkins-master.yaml
@@ -25,14 +25,11 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: jenkins-master-svc
+  name: jenkins-master
   namespace: cicd
-  annotations:
-    cloud.google.com/load-balancer-type: "Internal"
   labels:
     app: jenkins-master
 spec:
-  type: LoadBalancer
   ports:
   - port: 80
     targetPort: 8080
@@ -126,7 +123,7 @@ spec:
     istio: private-ingressgateway # use istio default controller
   servers:
     - port:
-        number: 8080
+        number: 80
         name: http
         protocol: HTTP
       hosts:
@@ -136,7 +133,7 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
-  name: jenkinsservice
+  name: jenkins-master
   namespace: cicd
 spec:
   hosts:
@@ -144,11 +141,14 @@ spec:
   gateways:
     - jenkins-gateway
   http:
-    - route:
+    - match:
+        - uri:
+            prefix: /jenkins-service
+      route:
         - destination:
-            host: jenkins-master
+            host: jenkins-master.cicd.svc.cluster.local
             port:
-              number: 8080
+              number: 80
       corsPolicy:
         allowOrigin:
           - "*"
@@ -161,3 +161,17 @@ spec:
           - DELETE
         allowHeaders:
           - "*"
+---
+### Jenkins Destination Rule ###
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: jenkins-master
+  namespace: cicd
+  annotations:
+    cloud.google.com/load-balancer-type: "Internal"
+spec:
+  host: jenkins-master.cicd.svc.cluster.local
+  trafficPolicy:
+    loadBalancer:
+      simple: LEAST_CONN

--- a/tb-gcp-tr/shared-dac/jenkins-master.yaml
+++ b/tb-gcp-tr/shared-dac/jenkins-master.yaml
@@ -31,7 +31,7 @@ metadata:
     app: jenkins-master
 spec:
   ports:
-  - port: 8080
+  - port: 80
     targetPort: 8080
     protocol: TCP
     name: http
@@ -69,6 +69,7 @@ spec:
       containers:
        - name: jenkins-master
          image: gcr.io/tranquility-base-images/tb-jenkins_latest:landingzone
+         args: ["--prefix=/jenkins-service"]
          securityContext:
             privileged: true
             runAsUser: 0
@@ -148,7 +149,7 @@ spec:
         - destination:
             host: jenkins-master.cicd.svc.cluster.local
             port:
-              number: 8080
+              number: 80
       corsPolicy:
         allowOrigin:
           - "*"

--- a/tb-gcp-tr/shared-dac/jenkins-master.yaml
+++ b/tb-gcp-tr/shared-dac/jenkins-master.yaml
@@ -148,7 +148,7 @@ spec:
         - destination:
             host: jenkins-master.cicd.svc.cluster.local
             port:
-              number: 80
+              number: 8080
       corsPolicy:
         allowOrigin:
           - "*"

--- a/tb-gcp-tr/shared-dac/jenkins-master.yaml
+++ b/tb-gcp-tr/shared-dac/jenkins-master.yaml
@@ -148,7 +148,7 @@ spec:
         - destination:
             host: jenkins-master.cicd.svc.cluster.local
             port:
-              number: 8080
+              number: 80
       corsPolicy:
         allowOrigin:
           - "*"

--- a/tb-gcp-tr/shared-dac/jenkins-master.yaml
+++ b/tb-gcp-tr/shared-dac/jenkins-master.yaml
@@ -31,7 +31,7 @@ metadata:
     app: jenkins-master
 spec:
   ports:
-  - port: 80
+  - port: 8080
     targetPort: 8080
     protocol: TCP
     name: http
@@ -148,7 +148,7 @@ spec:
         - destination:
             host: jenkins-master.cicd.svc.cluster.local
             port:
-              number: 80
+              number: 8080
       corsPolicy:
         allowOrigin:
           - "*"


### PR DESCRIPTION
## PR Type  
What kind of change does this PR introduce?  
  
1. This PR Create a separate gateway for jenkins in the cicd namespace

2. Also Creates a sepate virtualservice and destination rule for jenkins, so that when you hit the private gateway endpoint with the /jenkins-service prefix, it should bring up the jenkins service

3. This PR also changes the jenkins kubernetes service config from a loadbalancer to a clusterip.


Please check the boxes that applies to this PR.  
  
- [ ]  Namespace updates


## Purpose 
Jenkins service can now be accessed using eagle-console.private.landing-zone.com/jenkins-service

This PR prevents the need for jenkins service having to be accessed through a separate DNS name.
  
## Reviewers  

  
  ## Checklist  
 - [ ] This PR is linked to one or more issues.  
 - [ ] This PR has been tested (attach evidence if possible).  
 - [ ] This PR has passed style guidelines.  
