### PR TITLE
removed default net creation

### DIFF
--- a/tb-marketplace/tb-config-creator/tb-config-creator
+++ b/tb-marketplace/tb-config-creator/tb-config-creator
@@ -251,13 +251,18 @@ gcloud --project "${PROJECT_ID}" services enable runtimeconfig.googleapis.com
 
 echo "Essential APIs activated."
 
-# best practice (needs to be done after compute API is enabled)
-echo "Deleting default network..."
-gcloud compute firewall-rules delete projects/"${PROJECT_ID}"/global/firewalls/default-allow-icmp --quiet
-gcloud compute firewall-rules delete projects/"${PROJECT_ID}"/global/firewalls/default-allow-rdp --quiet
-gcloud compute firewall-rules delete projects/"${PROJECT_ID}"/global/firewalls/default-allow-ssh --quiet
-gcloud compute firewall-rules delete projects/"${PROJECT_ID}"/global/firewalls/default-allow-internal --quiet
-gcloud compute networks delete projects/"${PROJECT_ID}"/global/networks/default --quiet
+echo "Checking if the default VPC network was created on compute.googleapis.com activation..."
+if [[ -n "$(gcloud --project ${PROJECT_ID} compute networks list --filter='name=default' --format='value(name)' 2> /dev/null)" ]]; then
+  echo "The default VPC network was created. Deleting it as per best practices..."
+  gcloud compute firewall-rules delete projects/"${PROJECT_ID}"/global/firewalls/default-allow-icmp --quiet
+  gcloud compute firewall-rules delete projects/"${PROJECT_ID}"/global/firewalls/default-allow-rdp --quiet
+  gcloud compute firewall-rules delete projects/"${PROJECT_ID}"/global/firewalls/default-allow-ssh --quiet
+  gcloud compute firewall-rules delete projects/"${PROJECT_ID}"/global/firewalls/default-allow-internal --quiet
+  gcloud compute networks delete projects/"${PROJECT_ID}"/global/networks/default --quiet
+  echo "Finished deleting the default VPC network."
+else
+  echo "The default VPC network was not created."
+fi
 
 echo
 echo "Configuration completed!"

--- a/tb-marketplace/tb-config-creator/tb-config-creator
+++ b/tb-marketplace/tb-config-creator/tb-config-creator
@@ -250,15 +250,6 @@ gcloud --project "${PROJECT_ID}" services enable storage-api.googleapis.com
 gcloud --project "${PROJECT_ID}" services enable runtimeconfig.googleapis.com
 
 echo "Essential APIs activated."
-
-# best practice (needs to be done after compute API is enabled)
-echo "Deleting default network..."
-gcloud compute firewall-rules delete projects/"${PROJECT_ID}"/global/firewalls/default-allow-icmp --quiet
-gcloud compute firewall-rules delete projects/"${PROJECT_ID}"/global/firewalls/default-allow-rdp --quiet
-gcloud compute firewall-rules delete projects/"${PROJECT_ID}"/global/firewalls/default-allow-ssh --quiet
-gcloud compute firewall-rules delete projects/"${PROJECT_ID}"/global/firewalls/default-allow-internal --quiet
-gcloud compute networks delete projects/"${PROJECT_ID}"/global/networks/default --quiet
-
 echo
 echo "Configuration completed!"
 echo "You can now deploy Tranquility Base from Marketplace in project [${PROJECT_ID}], in the [${TBASE_FOLDER_NAME}] folder"

--- a/tb-marketplace/tb-config-creator/tb-config-creator
+++ b/tb-marketplace/tb-config-creator/tb-config-creator
@@ -250,6 +250,15 @@ gcloud --project "${PROJECT_ID}" services enable storage-api.googleapis.com
 gcloud --project "${PROJECT_ID}" services enable runtimeconfig.googleapis.com
 
 echo "Essential APIs activated."
+
+# best practice (needs to be done after compute API is enabled)
+echo "Deleting default network..."
+gcloud compute firewall-rules delete projects/"${PROJECT_ID}"/global/firewalls/default-allow-icmp --quiet
+gcloud compute firewall-rules delete projects/"${PROJECT_ID}"/global/firewalls/default-allow-rdp --quiet
+gcloud compute firewall-rules delete projects/"${PROJECT_ID}"/global/firewalls/default-allow-ssh --quiet
+gcloud compute firewall-rules delete projects/"${PROJECT_ID}"/global/firewalls/default-allow-internal --quiet
+gcloud compute networks delete projects/"${PROJECT_ID}"/global/networks/default --quiet
+
 echo
 echo "Configuration completed!"
 echo "You can now deploy Tranquility Base from Marketplace in project [${PROJECT_ID}], in the [${TBASE_FOLDER_NAME}] folder"


### PR DESCRIPTION
## PR Type  
What kind of change does this PR introduce?  
  
Please check the boxes that applies to this PR.  
  
- [ ] Bugfix  
- [ ] Feature  
- [ ] Code style update (formatting, local variables)  
- [x] Refactoring (no functional changes, no api changes)  
- [ ] Build related changes  
- [ ] CI related changes  
- [ ] Documentation content changes  
- [ ] TranquilityBase application / infrastructure changes  
- [ ] Other... Please describe:  


## Purpose 
Describe the problem or feature with a **link** to the issues.    
Also please describe which sections of the code do what and for what reason.  
 
Removed the default firewall rule deletion commands from tb-config-creator, which will be replaced with org policy skip default network creation rule. 

![image](https://user-images.githubusercontent.com/64899361/92883888-36d47e00-f409-11ea-8a01-31aaf9e7f7c6.png)


Needs to be merged at the same time as the policy is enabled to avoid disrupting deployments.
## Reviewers  
 - **Reviewer A** please review this part.  
 - **Review B** please review this part.  
  
  ## Checklist  
 - [x] This PR is linked to one or more issues.  
 - [x] This PR has been tested (attach evidence if possible).  
 - [ ] This PR has passed style guidelines.  
