### PR TITLE
Issue 452

### DIFF
--- a/tb-gcp-deploy/pack/init-no-itop.sh
+++ b/tb-gcp-deploy/pack/init-no-itop.sh
@@ -93,11 +93,8 @@ mkdir -p /opt/tb
 mv repo /opt/tb/
 mv tb-gcp-tr /opt/tb/repo
 
-# create certificate
+# create certificate directory
 mkdir -p /opt/certs
-openssl req -x509 -sha256 -nodes -days 365 -newkey rsa:2048 -subj '/O=TB Inc./CN=private.landing-zone.com' -keyout /opt/certs/private.landing-zone.com.key -out /opt/certs/private.landing-zone.com.crt
-openssl req -out /opt/certs/eagle-console.private.landing-zone.com.csr -newkey rsa:2048 -nodes -keyout /opt/certs/eagle-console.private.landing-zone.com.key -subj "/CN=eagle-console.private.landing-zone.com/O=eagle-console organization"
-openssl x509 -req -days 365 -CA /opt/certs/private.landing-zone.com.crt -CAkey /opt/certs/private.landing-zone.com.key -set_serial 0 -in /opt/certs/eagle-console.private.landing-zone.com.csr -out /opt/certs/eagle-console.private.landing-zone.com.crt
 
 #Navigate to Landing Zone working dir
 cd /opt/tb/repo/tb-gcp-tr/landingZone/no-itop/

--- a/tb-gcp-deploy/pack/packer-no-itop.json
+++ b/tb-gcp-deploy/pack/packer-no-itop.json
@@ -151,6 +151,11 @@
       "destination": "repo/"
     },
     {
+      "type": "file",
+      "source": "{{user `tb_repos_root_path`}}/tb-gcp-tr/tls",
+      "destination": "tb-gcp-tr/"
+    },
+    {
       "type": "shell",
       "script": "{{user `tb_repos_root_path`}}/tb-gcp-deploy/pack/init-no-itop.sh",
       "execute_command": "echo 'packer' | sudo -S sh -c '{{ .Vars }} {{ .Path }}'"

--- a/tb-gcp-tr/landingZone/create-private-ingress-gateway.sh
+++ b/tb-gcp-tr/landingZone/create-private-ingress-gateway.sh
@@ -5,9 +5,7 @@ kubectl apply -f /opt/tb/repo/tb-gcp-tr/landingZone/istio-pvt-ingressgateway.yam
 kubectl delete svc istio-ingressgateway --namespace=istio-system
 
 ## create secret
-kubectl create -n istio-system secret tls ec-tls-credential --key=/opt/certs/eagle-console.private.landing-zone.com.key --cert=/opt/certs/eagle-console.private.landing-zone.com.crt
-
-
+kubectl create -n istio-system secret tls ec-tls-credential --key=/opt/certs/eagle-console.ca.pem --cert=/opt/certs/eagle-console.crt.pem
 ## record ip with Cloud DNS
 service_desc=($(kubectl describe services istio-private-ingressgateway --namespace=istio-system | grep 'LoadBalancer Ingress:'))
 endpoint_ip=${service_desc[2]}
@@ -17,5 +15,5 @@ PROJECT_ID=$(curl -s "http://metadata.google.internal/computeMetadata/v1/project
 TB_DISCRIMINATOR="${PROJECT_ID: -8}"
 SHARED_NETWORKING_PROJECT=shared-networking-${TB_DISCRIMINATOR}
 gcloud dns --project="${SHARED_NETWORKING_PROJECT}" record-sets transaction start --zone=private-shared
-gcloud beta dns --project="${SHARED_NETWORKING_PROJECT}" record-sets transaction add "${endpoint_ip}" --name=eagle-console.private.landing-zone.com. --ttl=300 --type=A --zone=private-shared
+gcloud beta dns --project="${SHARED_NETWORKING_PROJECT}" record-sets transaction add "${endpoint_ip}" --name=eagle-console.tranquilitybase.internal. --ttl=300 --type=A --zone=private-shared
 gcloud beta dns --project="${SHARED_NETWORKING_PROJECT}" record-sets transaction execute --zone=private-shared

--- a/tb-gcp-tr/landingZone/create-private-ingress-gateway.sh
+++ b/tb-gcp-tr/landingZone/create-private-ingress-gateway.sh
@@ -5,7 +5,7 @@ kubectl apply -f /opt/tb/repo/tb-gcp-tr/landingZone/istio-pvt-ingressgateway.yam
 kubectl delete svc istio-ingressgateway --namespace=istio-system
 
 ## create secret
-kubectl create -n istio-system secret tls ec-tls-credential --key=/opt/certs/eagle-console.ca.pem --cert=/opt/certs/eagle-console.crt.pem
+kubectl create -n istio-system secret tls ec-tls-credential --cert=/opt/certs/eagle-console.crt.pem --key=/opt/certs/eagle-console.key.pem
 ## record ip with Cloud DNS
 service_desc=($(kubectl describe services istio-private-ingressgateway --namespace=istio-system | grep 'LoadBalancer Ingress:'))
 endpoint_ip=${service_desc[2]}

--- a/tb-gcp-tr/landingZone/no-itop/input.tfvars
+++ b/tb-gcp-tr/landingZone/no-itop/input.tfvars
@@ -30,8 +30,8 @@ gke_pod_network_name     = "gke-pods-snet"
 gke_service_network_name = "gke-services-snet"
 
 #CLOUD DNS
-private_dns_name        = "private-shared"
-private_dns_domain_name = "private.landing-zone.com." # domain requires . to finish
+#private_dns_name        = "private-shared"
+#private_dns_domain_name = "private.landing-zone.com." # domain requires . to finish
 
 #KUBERNETES EC CLUSTER
 cluster_ec_subnetwork              = "shared-ec-snet"

--- a/tb-gcp-tr/landingZone/no-itop/main.tf
+++ b/tb-gcp-tr/landingZone/no-itop/main.tf
@@ -42,6 +42,10 @@ provider "kubernetes" {
   version = "~> 1.12"
 }
 
+provider "tls" {
+  version = "~> 2.2"
+}
+
 terraform {
   backend "gcs" {
     # The bucket name below is overloaded at every run with
@@ -192,6 +196,9 @@ module "k8s-ec_context" {
   dependency_var  = module.gke-ec.node_id
 }
 
+module "tls" {
+  source = "../../tls"
+}
 ## Creating the ssp and cicd namespaces in the shared services cluster ## depends on the k8-ec_content module 
 module "SharedServices_namespace_creation" {
   source = "../../../tb-common-tr/start_service"

--- a/tb-gcp-tr/landingZone/no-itop/variables.tf
+++ b/tb-gcp-tr/landingZone/no-itop/variables.tf
@@ -343,13 +343,13 @@ variable "ec_ui_source_bucket" {
 
 variable "private_dns_name" {
   type        = string
-  default     = ""
+  default     = "private-shared"
   description = "Name for private DNS zone in the shared vpc network"
 }
 
 variable "private_dns_domain_name" {
   type        = string
-  default     = ""
+  default     = "tranquilitybase.internal." # domain requires . to finish
   description = "Domain name for private DNS in the shared vpc network"
 }
 ## DAC Services ##########

--- a/tb-gcp-tr/tls/main.tf
+++ b/tb-gcp-tr/tls/main.tf
@@ -39,7 +39,7 @@ resource "tls_private_key" "cert" {
   ecdsa_curve = var.private_key_ecdsa_curve
   rsa_bits    = var.private_key_rsa_bits
 
-  # Store the certificate's private key in a file.
+ 
   # Store the certificate's private key in a file.
   provisioner "local-exec" {
     command = "echo '${tls_private_key.cert.private_key_pem}' > '${var.private_key_file_path}' && chmod ${var.permissions} '${var.private_key_file_path}' && chown ${var.owner} '${var.private_key_file_path}'"
@@ -72,5 +72,4 @@ resource "tls_locally_signed_cert" "cert" {
   provisioner "local-exec" {
     command = "echo '${tls_locally_signed_cert.cert.cert_pem}' > '${var.public_key_file_path}' && chmod ${var.permissions} '${var.public_key_file_path}' && chown ${var.owner} '${var.public_key_file_path}'"
   }
-
 }

--- a/tb-gcp-tr/tls/main.tf
+++ b/tb-gcp-tr/tls/main.tf
@@ -1,0 +1,76 @@
+
+# ---------------------------------------------------------------------------------------------------------------------
+#  CREATE A CA CERTIFICATE
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "tls_private_key" "ca" {
+  algorithm   = var.private_key_algorithm
+  ecdsa_curve = var.private_key_ecdsa_curve
+  rsa_bits    = var.private_key_rsa_bits
+}
+
+
+resource "tls_self_signed_cert" "ca" {
+  key_algorithm     = tls_private_key.ca.algorithm
+  private_key_pem   = tls_private_key.ca.private_key_pem
+  is_ca_certificate = true
+
+  validity_period_hours = var.validity_period_hours
+  allowed_uses          = var.ca_allowed_uses
+
+  subject {
+    common_name  = var.ca_common_name
+    organization = var.organization_name
+  }
+  
+  provisioner "local-exec" {
+    command = "echo '${tls_self_signed_cert.ca.cert_pem}' > '${var.ca_public_key_file_path}' && chmod ${var.permissions} '${var.ca_public_key_file_path}' && chown ${var.owner} '${var.ca_public_key_file_path}'"
+  }
+}
+
+
+
+# ---------------------------------------------------------------------------------------------------------------------
+# CREATE A TLS CERTIFICATE SIGNED USING THE CA CERTIFICATE
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "tls_private_key" "cert" {
+  algorithm   = var.private_key_algorithm
+  ecdsa_curve = var.private_key_ecdsa_curve
+  rsa_bits    = var.private_key_rsa_bits
+
+  # Store the certificate's private key in a file.
+  # Store the certificate's private key in a file.
+  provisioner "local-exec" {
+    command = "echo '${tls_private_key.cert.private_key_pem}' > '${var.private_key_file_path}' && chmod ${var.permissions} '${var.private_key_file_path}' && chown ${var.owner} '${var.private_key_file_path}'"
+  }
+}
+resource "tls_cert_request" "cert" {
+  key_algorithm   = tls_private_key.cert.algorithm
+  private_key_pem = tls_private_key.cert.private_key_pem
+
+  dns_names    = var.dns_names
+  #ip_addresses = var.ip_addresses
+
+  subject {
+    common_name  = var.common_name
+    organization = var.organization_name
+  }
+}
+
+resource "tls_locally_signed_cert" "cert" {
+  cert_request_pem = tls_cert_request.cert.cert_request_pem
+
+  ca_key_algorithm   = tls_private_key.ca.algorithm
+  ca_private_key_pem = tls_private_key.ca.private_key_pem
+  ca_cert_pem        = tls_self_signed_cert.ca.cert_pem
+
+  validity_period_hours = var.validity_period_hours
+  allowed_uses          = var.allowed_uses
+
+  # Store the certificate's public key in a file.
+  provisioner "local-exec" {
+    command = "echo '${tls_locally_signed_cert.cert.cert_pem}' > '${var.public_key_file_path}' && chmod ${var.permissions} '${var.public_key_file_path}' && chown ${var.owner} '${var.public_key_file_path}'"
+  }
+
+}

--- a/tb-gcp-tr/tls/variables.tf
+++ b/tb-gcp-tr/tls/variables.tf
@@ -99,17 +99,17 @@ variable "permissions" {
 variable "ca_public_key_file_path" {
   description = "Write the PEM-encoded CA certificate public key to this path (e.g. /etc/tls/ca.crt.pem)."
   type        = string
-  default     = "/opt/certs/eagle-console.ca.pem"
+  default     = "/opt/certs/eagle-console.ca"
 }
 
 variable "public_key_file_path" {
   description = "Write the PEM-encoded certificate public key to this path (e.g. /etc/tls/cloudapps.crt.pem)."
   type        = string
-  default     = "/opt/certs/eagle-console.crt.pem"
+  default     = "/opt/certs/eagle-console.crt"
 }
 
 variable "private_key_file_path" {
   description = "Write the PEM-encoded certificate private key to this path (e.g. /etc/tls/cloudapps.key.pem)."
   type        = string
-  default     = "/opt/certs/eagle-console.key.pem"
+  default     = "/opt/certs/eagle-console.key"
 }

--- a/tb-gcp-tr/tls/variables.tf
+++ b/tb-gcp-tr/tls/variables.tf
@@ -1,0 +1,115 @@
+variable "private_key_algorithm" {
+  description = "The name of the algorithm to use for private keys. Must be one of: RSA or ECDSA."
+  type        = string
+  default     = "RSA"
+}
+
+variable "private_key_ecdsa_curve" {
+  description = "The name of the elliptic curve to use. Should only be used if var.private_key_algorithm is ECDSA. Must be one of P224, P256, P384 or P521."
+  type        = string
+  default     = "P256"
+}
+
+variable "private_key_rsa_bits" {
+  description = "The size of the generated RSA key in bits. Should only be used if var.private_key_algorithm is RSA."
+  type        = number
+  default     = 2048
+
+}
+
+variable "owner" {
+  description = "The OS user who should be given ownership over the certificate files."
+  type        = string
+  default     = "root"
+}
+
+variable "organization_name" {
+  description = "The name of the organization to associate with the certificates (e.g. Acme Co)."
+  type        = string
+  default     = "TB inc"
+}
+
+variable "ca_common_name" {
+  description = "The common name to use in the subject of the CA certificate (e.g. acme.co cert)."
+  type        = string
+  default     = "eagle-console.tranquilitybase.internal."
+}
+
+variable "common_name" {
+  description = "The common name to use in the subject of the certificate (e.g. acme.co cert)."
+  type        = string
+  default     = "eagle-console.tranquilitybase.internal."
+}
+
+variable "dns_names" {
+  description = "List of DNS names for which the certificate will be valid (e.g. foo.example.com)."
+  type        = list(string)
+  default     = ["eagle-console.tranquilitybase.internal."]
+}
+
+#variable "ip_addresses" {
+ # description = "List of IP addresses for which the certificate will be valid (e.g. 127.0.0.1)."
+  #type        = list(string)
+  #default     = ["127.0.0.1"]
+#}
+
+variable "validity_period_hours" {
+  description = "The number of hours after initial issuing that the certificate will become invalid."
+  type        = number
+  default     = 3600
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# OPTIONAL PARAMETERS
+# These parameters have reasonable defaults.
+# ---------------------------------------------------------------------------------------------------------------------
+
+variable "ca_allowed_uses" {
+  description = "List of keywords from RFC5280 describing a use that is permitted for the CA certificate. For more info and the list of keywords, see https://www.terraform.io/docs/providers/tls/r/self_signed_cert.html#allowed_uses."
+  type        = list(string)
+
+  default = [
+    "cert_signing",
+    "key_encipherment",
+    "digital_signature",
+  ]
+}
+
+variable "allowed_uses" {
+  description = "List of keywords from RFC5280 describing a use that is permitted for the issued certificate. For more info and the list of keywords, see https://www.terraform.io/docs/providers/tls/r/self_signed_cert.html#allowed_uses."
+  type        = list(string)
+
+  default = [
+    "key_encipherment",
+    "digital_signature",
+  ]
+}
+
+variable "permissions" {
+  description = "The Unix file permission to assign to the cert files (e.g. 0600)."
+  type        = number
+  default     = 0600
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# REQUIRED PARAMETERS
+# You must provide a value for each of these parameters.
+# ---------------------------------------------------------------------------------------------------------------------
+
+variable "ca_public_key_file_path" {
+  description = "Write the PEM-encoded CA certificate public key to this path (e.g. /etc/tls/ca.crt.pem)."
+  type        = string
+  default     = "/opt/certs/eagle-console.ca.pem"
+}
+
+variable "public_key_file_path" {
+  description = "Write the PEM-encoded certificate public key to this path (e.g. /etc/tls/cloudapps.crt.pem)."
+  type        = string
+  default     = "/opt/certs/eagle-console.crt.pem"
+}
+
+variable "private_key_file_path" {
+  description = "Write the PEM-encoded certificate private key to this path (e.g. /etc/tls/cloudapps.key.pem)."
+  type        = string
+  default     = "/opt/certs/eagle-console.key.pem"
+}

--- a/tb-gcp-tr/tls/variables.tf
+++ b/tb-gcp-tr/tls/variables.tf
@@ -99,17 +99,17 @@ variable "permissions" {
 variable "ca_public_key_file_path" {
   description = "Write the PEM-encoded CA certificate public key to this path (e.g. /etc/tls/ca.crt.pem)."
   type        = string
-  default     = "/opt/certs/eagle-console.ca"
+  default     = "/opt/certs/eagle-console.ca.pem"
 }
 
 variable "public_key_file_path" {
   description = "Write the PEM-encoded certificate public key to this path (e.g. /etc/tls/cloudapps.crt.pem)."
   type        = string
-  default     = "/opt/certs/eagle-console.crt"
+  default     = "/opt/certs/eagle-console.crt.pem"
 }
 
 variable "private_key_file_path" {
   description = "Write the PEM-encoded certificate private key to this path (e.g. /etc/tls/cloudapps.key.pem)."
   type        = string
-  default     = "/opt/certs/eagle-console.key"
+  default     = "/opt/certs/eagle-console.key.pem"
 }


### PR DESCRIPTION
## PR Type  
What kind of change does this PR introduce?  
  Have the option to select the URL\DNS host name which will be used for the Eagle Console and have the corresponding SSL certificate automatically created. new default name - https://eagle-console.tranquilitybase.internal.
Please check the boxes that applies to this PR.  
  
- [ ] Bugfix  
- [x ] Feature  
- [ ] Code style update (formatting, local variables)  
- [ ] Refactoring (no functional changes, no api changes)  
- [ ] Build related changes  
- [ ] CI related changes  
- [ ] Documentation content changes  
- [ ] TranquilityBase application / infrastructure changes  
- [ ] Other... Please describe:  



  
## Reviewers  
 - @RDHA-GFT 
 - @zain-GFT 
  
  ## Checklist  
 - [ ] This PR is linked to one or more issues.  
 - [x ] This PR has been tested (attach evidence if possible).  

Evidence TLS secretes get created 
![tls 2020-09-21 173449](https://user-images.githubusercontent.com/64811624/93798972-6455ce80-fc36-11ea-8f98-ce4aab8ec797.png)


Evidence Eagle console is accessible now via https://eagle-console.tranquilitybase.internal.
![ec 2020-09-21 181705](https://user-images.githubusercontent.com/64811624/93799979-d37ff280-fc37-11ea-987f-fd40b0a76d32.png)



Evidence certs get saves in a specified path /opt/certs
![env 2020-09-21 181828](https://user-images.githubusercontent.com/64811624/93800117-02966400-fc38-11ea-8abc-6dcd4e04e7ce.png)


 - [ ] This PR has passed style guidelines.  
