### PR TITLE
Issue 445

### DIFF
--- a/tb-common-tr/start_service/main.tf
+++ b/tb-common-tr/start_service/main.tf
@@ -15,6 +15,9 @@
 resource "null_resource" "kubernetes_resource" {
   triggers = {
     content = var.dependency_var
+    k8s_template = var.k8s_template_file
+    cluster_config_path = var.cluster_config_path
+    context = var.cluster_context
   }
 
   provisioner "local-exec" {
@@ -30,11 +33,11 @@ EOF
 
   provisioner "local-exec" {
     command = <<EOF
-echo 'kubectl_config_args="--kubeconfig=${var.cluster_config_path}"
-if [[ -n "${var.cluster_context}" ]]; then
-  kubectl_config_args="$kubectl_config_args --context=${var.cluster_context}"
+echo 'kubectl_config_args="--kubeconfig=${self.triggers.cluster_config_path}"
+if [[ -n "${self.triggers.context}" ]]; then
+  kubectl_config_args="$kubectl_config_args --context=${self.triggers.context}"
 fi
-kubectl $kubectl_config_args delete -f ${var.k8s_template_file}' | tee -a /opt/tb/repo/tb-gcp-tr/landingZone/kube.sh
+kubectl $kubectl_config_args delete -f ${self.triggers.k8s_template}' | tee -a /opt/tb/repo/tb-gcp-tr/landingZone/kube.sh
 EOF
 
 

--- a/tb-common-tr/start_service/main.tf
+++ b/tb-common-tr/start_service/main.tf
@@ -14,10 +14,10 @@
 
 resource "null_resource" "kubernetes_resource" {
   triggers = {
-    content = var.dependency_var
-    k8s_template = var.k8s_template_file
+    content             = var.dependency_var
+    k8s_template        = var.k8s_template_file
     cluster_config_path = var.cluster_config_path
-    context = var.cluster_context
+    context             = var.cluster_context
   }
 
   provisioner "local-exec" {

--- a/tb-common-tr/start_service/versions.tf
+++ b/tb-common-tr/start_service/versions.tf
@@ -1,4 +1,4 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
 }

--- a/tb-gcp-deploy/pack/init-no-itop.sh
+++ b/tb-gcp-deploy/pack/init-no-itop.sh
@@ -69,8 +69,8 @@ cat <<EOF > /etc/google-fluentd/config.d/bootstrap-log.conf
 EOF
 systemctl restart google-fluentd
 
-# install Terraform 0.11
-wget https://releases.hashicorp.com/terraform/0.12.9/terraform_0.12.9_linux_amd64.zip
+# install Terraform 0.13
+wget https://releases.hashicorp.com/terraform/0.13.3/terraform_0.13.3_linux_amd64.zip
 apt-get -y update
 apt-get -y install unzip
 apt-get -y install zip
@@ -85,8 +85,8 @@ npm install -g @angular/cli
 node -v
 npm -v
 
-unzip -d /usr/local/bin/ terraform_0.12.9_linux_amd64.zip
-rm terraform_0.12.9_linux_amd64.zip
+unzip -d /usr/local/bin/ terraform_0.13.3_linux_amd64.zip
+rm terraform_0.13.3_linux_amd64.zip
 
 # move TB Repo files from packer's home directory to target /opt/tb/repo directory
 mkdir -p /opt/tb

--- a/tb-gcp-tr/apis-activation/versions.tf
+++ b/tb-gcp-tr/apis-activation/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_version = ">= 0.13"
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source  = "hashicorp/google"
       version = "~>3.3"
     }
   }

--- a/tb-gcp-tr/apis-activation/versions.tf
+++ b/tb-gcp-tr/apis-activation/versions.tf
@@ -1,4 +1,10 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      version = "~>3.3"
+    }
+  }
 }

--- a/tb-gcp-tr/bootstrap/versions.tf
+++ b/tb-gcp-tr/bootstrap/versions.tf
@@ -1,4 +1,13 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      version = "~> 3.3"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+  }
 }

--- a/tb-gcp-tr/bootstrap/versions.tf
+++ b/tb-gcp-tr/bootstrap/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_version = ">= 0.13"
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source  = "hashicorp/google"
       version = "~> 3.3"
     }
     random = {

--- a/tb-gcp-tr/folder-structure-creation/examples/advanced/versions.tf
+++ b/tb-gcp-tr/folder-structure-creation/examples/advanced/versions.tf
@@ -1,4 +1,4 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
 }

--- a/tb-gcp-tr/folder-structure-creation/examples/simple/versions.tf
+++ b/tb-gcp-tr/folder-structure-creation/examples/simple/versions.tf
@@ -1,4 +1,4 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
 }

--- a/tb-gcp-tr/folder-structure-creation/versions.tf
+++ b/tb-gcp-tr/folder-structure-creation/versions.tf
@@ -1,4 +1,4 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
 }

--- a/tb-gcp-tr/gae-self-service-portal/main.tf
+++ b/tb-gcp-tr/gae-self-service-portal/main.tf
@@ -46,8 +46,8 @@ resource "null_resource" "sync-ec-ui-buckets" {
   depends_on = [
     google_storage_bucket.ec-ui-static-files
   ]
-    triggers = {
-    source_bucket  = var.source_bucket
+  triggers = {
+    source_bucket      = var.source_bucket
     ec-ui-static-files = google_storage_bucket.ec-ui-static-files.name
   }
 }
@@ -63,8 +63,8 @@ resource "null_resource" "copy-endpoint-meta" {
     command = "cp ${var.endpoint_file} ${var.ui-source-local}/dist/tb-self-service-portal/assets/"
   }
   depends_on = [null_resource.ec_gke_cluster_endpoint_retrieved]
-    triggers = {
-    endpoint_file = var.endpoint_file
+  triggers = {
+    endpoint_file   = var.endpoint_file
     ui-source-local = var.ui-source-local
   }
 }

--- a/tb-gcp-tr/gae-self-service-portal/versions.tf
+++ b/tb-gcp-tr/gae-self-service-portal/versions.tf
@@ -1,4 +1,4 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
 }

--- a/tb-gcp-tr/helm-pre-requisites/versions.tf
+++ b/tb-gcp-tr/helm-pre-requisites/versions.tf
@@ -1,4 +1,10 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+      version = ">=0.12"
+    }
+  }
 }

--- a/tb-gcp-tr/helm-pre-requisites/versions.tf
+++ b/tb-gcp-tr/helm-pre-requisites/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_version = ">= 0.13"
   required_providers {
     kubernetes = {
-      source = "hashicorp/kubernetes"
+      source  = "hashicorp/kubernetes"
       version = ">=0.12"
     }
   }

--- a/tb-gcp-tr/itop/examples/simple/versions.tf
+++ b/tb-gcp-tr/itop/examples/simple/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/tb-gcp-tr/itop/versions.tf
+++ b/tb-gcp-tr/itop/versions.tf
@@ -1,4 +1,21 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+    helm = {
+      source = "hashicorp/helm"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+    null = {
+      source = "hashicorp/null"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+  }
 }

--- a/tb-gcp-tr/k8s-context/main.tf
+++ b/tb-gcp-tr/k8s-context/main.tf
@@ -14,9 +14,9 @@
 
 resource "null_resource" "k8s_config" {
   triggers = {
-    content = var.dependency_var
-    cluster_name = var.cluster_name
-    region = var.region
+    content         = var.dependency_var
+    cluster_name    = var.cluster_name
+    region          = var.region
     cluster_project = var.cluster_project
   }
   provisioner "local-exec" {

--- a/tb-gcp-tr/k8s-context/main.tf
+++ b/tb-gcp-tr/k8s-context/main.tf
@@ -15,6 +15,9 @@
 resource "null_resource" "k8s_config" {
   triggers = {
     content = var.dependency_var
+    cluster_name = var.cluster_name
+    region = var.region
+    cluster_project = var.cluster_project
   }
   provisioner "local-exec" {
     command = <<EOT

--- a/tb-gcp-tr/k8s-context/versions.tf
+++ b/tb-gcp-tr/k8s-context/versions.tf
@@ -1,4 +1,9 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    null = {
+      source = "hashicorp/null"
+    }
+  }
 }

--- a/tb-gcp-tr/kubernetes-cluster-creation/gke.tf
+++ b/tb-gcp-tr/kubernetes-cluster-creation/gke.tf
@@ -1,11 +1,11 @@
 # Copyright 2019 The Tranquility Base Authors
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,7 +16,7 @@ resource "google_container_cluster" "gke" {
   project  = var.cluster_project_id
   name     = var.cluster_name
   location = var.region
-  provider = google-beta.shared-vpc
+  provider = google-beta
 
   # We can't create a cluster with no node pool defined, but we want to only use
   # separately managed node pools. So we create the smallest possible default

--- a/tb-gcp-tr/kubernetes-cluster-creation/iam.tf
+++ b/tb-gcp-tr/kubernetes-cluster-creation/iam.tf
@@ -1,26 +1,16 @@
 # Copyright 2019 The Tranquility Base Authors
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-# separate google-beta provider needed to assign sharedvpc networkUser permissions
-provider "google" {
-  version = "~> 3.3"
-}
-
-provider "google-beta" {
-  alias   = "shared-vpc"
-  version = "~> 3.3"
-}
 
 # create compute service account for kubernetes cluster
 resource "google_service_account" "cluster" {
@@ -66,7 +56,7 @@ resource "google_project_iam_member" "cluster_hostServiceAgentUser" {
 
 # grant access to subnetwork with networkUser permissions to cluster service account in shared-vpc
 resource "google_compute_subnetwork_iam_member" "cluster_networkUser_1" {
-  provider   = google-beta.shared-vpc
+  project    = var.sharedvpc_project_id
   subnetwork = var.cluster_subnetwork
   role       = "roles/compute.networkUser"
   member = format(
@@ -77,7 +67,7 @@ resource "google_compute_subnetwork_iam_member" "cluster_networkUser_1" {
 }
 
 resource "google_compute_subnetwork_iam_member" "cluster_networkUser_2" {
-  provider   = google-beta.shared-vpc
+  project    = var.sharedvpc_project_id
   subnetwork = var.cluster_subnetwork
   role       = "roles/compute.networkUser"
   member = format(

--- a/tb-gcp-tr/kubernetes-cluster-creation/variables.tf
+++ b/tb-gcp-tr/kubernetes-cluster-creation/variables.tf
@@ -134,6 +134,11 @@ variable "shared_vpc_dependency" {
   description = "Creates dependency on shared-vpc module"
 }
 
+variable "shared_ec_dependency" {
+  type        = string
+  description = "Creates dependency on shared_projects"
+}
+
 variable "istio_permissive_mtls" {
   type    = string
   default = "false"

--- a/tb-gcp-tr/kubernetes-cluster-creation/versions.tf
+++ b/tb-gcp-tr/kubernetes-cluster-creation/versions.tf
@@ -1,4 +1,17 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 3.3"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~> 3.3"
+    }
+    null = {
+      source = "hashicorp/null"
+    }
+  }
 }

--- a/tb-gcp-tr/landingZone/no-itop/data_sources.tf
+++ b/tb-gcp-tr/landingZone/no-itop/data_sources.tf
@@ -1,4 +1,4 @@
- # Copyright 2019 The Tranquility Base Authors
+# Copyright 2019 The Tranquility Base Authors
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tb-gcp-tr/landingZone/no-itop/data_sources.tf
+++ b/tb-gcp-tr/landingZone/no-itop/data_sources.tf
@@ -1,4 +1,4 @@
-# Copyright 2019 The Tranquility Base Authors
+ # Copyright 2019 The Tranquility Base Authors
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tb-gcp-tr/landingZone/no-itop/main.tf
+++ b/tb-gcp-tr/landingZone/no-itop/main.tf
@@ -52,7 +52,7 @@ terraform {
       version = "~> 3.3"
     }
     kubernetes = {
-      source = "hashicorp/kubernetes"g
+      source = "hashicorp/kubernetes"
     }
     local = {
       source = "hashicorp/local"

--- a/tb-gcp-tr/landingZone/no-itop/main.tf
+++ b/tb-gcp-tr/landingZone/no-itop/main.tf
@@ -16,17 +16,17 @@
 # Root module (activates other modules)
 ###
 provider "google" {
-  region  = var.region
-  zone    = var.region_zone
+  region = var.region
+  zone   = var.region_zone
 }
 
 provider "google-beta" {
-  region  = var.region
-  zone    = var.region_zone
+  region = var.region
+  zone   = var.region_zone
 }
 
 provider "kubernetes" {
-  alias   = "k8s"
+  alias = "k8s"
 }
 
 provider "tls" {
@@ -183,10 +183,10 @@ module "gke-ec" {
   istio_status             = var.istio_status
   gke_pod_network_name     = var.gke_pod_network_name
   gke_service_network_name = var.gke_service_network_name
-  
+
   depends_on = [
-  module.shared_projects.shared_networking_id, 
-  module.shared_projects.shared_ec_id
+    module.shared_projects.shared_networking_id,
+    module.shared_projects.shared_ec_id
   ]
 
 }

--- a/tb-gcp-tr/landingZone/no-itop/versions.tf
+++ b/tb-gcp-tr/landingZone/no-itop/versions.tf
@@ -1,4 +1,4 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
 }

--- a/tb-gcp-tr/landingZone/tb-welcome
+++ b/tb-gcp-tr/landingZone/tb-welcome
@@ -39,7 +39,6 @@ MAX_ATTEMPTS=10
 MAX_ATTEMPTS_INIT=3
 DELAY_BETWEEN_ATTEMPTS=60
 export HOME=/root
-
 #Initialise variables
 SA_NAME="bootstrap-sa"
 SA_EMAIL=${SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com

--- a/tb-gcp-tr/logging-export/versions.tf
+++ b/tb-gcp-tr/logging-export/versions.tf
@@ -1,9 +1,8 @@
-
 terraform {
-  required_version = ">= 0.13"
   required_providers {
     google = {
       source = "hashicorp/google"
     }
   }
+  required_version = ">= 0.13"
 }

--- a/tb-gcp-tr/logging-folder-sink/versions.tf
+++ b/tb-gcp-tr/logging-folder-sink/versions.tf
@@ -1,9 +1,8 @@
-
 terraform {
-  required_version = ">= 0.13"
   required_providers {
     google = {
       source = "hashicorp/google"
     }
   }
+  required_version = ">= 0.13"
 }

--- a/tb-gcp-tr/shared-projects-creation/versions.tf
+++ b/tb-gcp-tr/shared-projects-creation/versions.tf
@@ -1,4 +1,9 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
 }

--- a/tb-gcp-tr/shared-vpc/examples/advanced/providers.tf
+++ b/tb-gcp-tr/shared-vpc/examples/advanced/providers.tf
@@ -17,4 +17,3 @@ provider "google" {
   zone    = var.region_zone
   version = "~> 3.3"
 }
-

--- a/tb-gcp-tr/shared-vpc/examples/advanced/versions.tf
+++ b/tb-gcp-tr/shared-vpc/examples/advanced/versions.tf
@@ -1,4 +1,4 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
 }

--- a/tb-gcp-tr/shared-vpc/examples/simple/versions.tf
+++ b/tb-gcp-tr/shared-vpc/examples/simple/versions.tf
@@ -1,4 +1,4 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
 }

--- a/tb-gcp-tr/shared-vpc/versions.tf
+++ b/tb-gcp-tr/shared-vpc/versions.tf
@@ -1,4 +1,9 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
 }

--- a/tb-gcp-tr/single-bastion/versions.tf
+++ b/tb-gcp-tr/single-bastion/versions.tf
@@ -1,4 +1,9 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
 }

--- a/tb-oss/source/hashicorp.terraform.zip
+++ b/tb-oss/source/hashicorp.terraform.zip
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:872245d9c6302b24dc0d98a1e010aef1e4ef60865a2d1f60102c8ad03e9d5a1d
-size 28424050
+oid sha256:6867f6cdd6d19f602aaba0ab0425dcd6a4044bfe8cac9ebc61e007cca9bd7c1e
+size 17035064


### PR DESCRIPTION
## PR Type  
What kind of change does this PR introduce?  

Upgrades the Terraform version to 0.13.3

- Adds triggers for destroy time provisioners

- Adds required providers blocks for all modules

- Upgrades the provider version to the latest (3.42)

- Upgrades LFS

- Moves provider config to root module.

- Adds explicit depends_on for the shared ec and shared networking projects on the gke module.

Please check the boxes that applies to this PR.  
  
- [ ] Bugfix  
- [x] Feature  
- [ ] Code style update (formatting, local variables)  
- [ ] Refactoring (no functional changes, no api changes)  
- [ ] Build related changes  
- [ ] CI related changes  
- [ ] Documentation content changes  
- [ ] TranquilityBase application / infrastructure changes  
- [ ] Other... Please describe:  


## Purpose 
Describe the problem or feature with a **link** to the issues.    
Also please describe which sections of the code do what and for what reason.  

Allows enhancements described in https://www.terraform.io/upgrade-guides/0-13.html 
Required for multiple race condition fixes
  
## Reviewers  
 - **Reviewer A** please review this part.  
 - **Review B** please review this part.  
  
  ## Checklist  
 - [x] This PR is linked to one or more issues.  
 - [x] This PR has been tested (attach evidence if possible).  
![image](https://user-images.githubusercontent.com/64899361/95197672-dc44fc80-07d1-11eb-9d9b-341297df5b1e.png)

 - [ ] This PR has passed style guidelines.  
