### PR TITLE
Fixes #503 consolidate bastion & proxy FW rules

### DIFF
--- a/tb-gcp-tr/landingZone/no-itop/main.tf
+++ b/tb-gcp-tr/landingZone/no-itop/main.tf
@@ -132,7 +132,6 @@ module "bastion-security" {
   region_zone                   = var.region_zone
   shared_bastion_id             = module.shared_projects.shared_bastion_id
   shared_networking_id          = module.shared_projects.shared_networking_id
-  nat_static_ip                 = module.shared-vpc.nat_static_ip
   root_id                       = var.root_id
   shared_bastion_project_number = module.shared_projects.shared_bastion_project_number
 }
@@ -263,7 +262,6 @@ module "SharedServices_jenkinsmaster_creation" {
   cluster_context   = module.k8s-ec_context.context_name
   dependency_var    = null_resource.kubernetes_jenkins_service_account_key_secret.id
 }
-
 
 module "SharedServices_configuration_file" {
   source = "../../../tb-common-tr/start_service"

--- a/tb-gcp-tr/shared-bastion/variables.tf
+++ b/tb-gcp-tr/shared-bastion/variables.tf
@@ -26,11 +26,6 @@ variable "shared_networking_id" {
   description = "identifier for the shared_networking project."
 }
 
-variable "nat_static_ip" {
-  type        = string
-  description = "NAT Static IP"
-}
-
 variable root_id {
   type        = string
   description = "ID for the parent organisation where folders will be created"

--- a/tb-gcp-tr/shared-vpc/main.tf
+++ b/tb-gcp-tr/shared-vpc/main.tf
@@ -97,6 +97,28 @@ resource "google_compute_subnetwork" "shared-bastion-subnetwork" {
   depends_on = [
   google_compute_network.shared_network]
 }
+
+###
+# Base Firewall resources
+###
+resource "google_compute_firewall" "allow_iap_ingress" {
+  name        = "allow-iap-ingress"
+  network     = google_compute_network.shared_network.self_link
+  project     = var.host_project_id
+  description = "Allow inbound connections from Identity-Aware Proxy"
+  direction   = "INGRESS"
+
+  allow {
+    protocol = "tcp"
+  }
+
+  log_config {
+    metadata = "INCLUDE_ALL_METADATA"
+  }
+
+  source_ranges = ["35.235.240.0/20"]
+}
+
 ###
 # Additional Networking Resources
 ###


### PR DESCRIPTION
## PR Type  
Changes the Shared VPC default firewall rules to the following three:

### Allow inbound connections from bastion servers
Name: allow-bastion-ingress
Direction: INGRESS
Source: any GCE instance running with the bastion-service-account service account
Destination ports: all TCP ports on all GCE instances

### Allow inbound connections from Identity-Aware Proxy

Name: allow-iap-ingress
Direction: INGRESS
Destination ports: all TCP ports on all GCE instances
Source: 35.235.240.0/20 (these are the known Identity-Aware Proxy ranges)

### Allow inbound connections from proxy servers
Name: allow-proxy-http-ingress
Direction: INGRESS
Destination ports: TCP ports 80, 443, 8008, 8080 and 8443 on all GCE instances
Source: any GCE instance running with the proxy-sa service account
  
Please check the boxes that applies to this PR.  
  
- [ ] Bugfix  
- [X] Feature  
- [ ] Code style update (formatting, local variables)  
- [ ] Refactoring (no functional changes, no api changes)  
- [ ] Build related changes  
- [ ] CI related changes  
- [ ] Documentation content changes  
- [ ] TranquilityBase application / infrastructure changes  
- [ ] Other... Please describe:  

## Purpose 
Remove test firewall rules and other unneeded sources such as the NAT Gateway's IP.
  
## Reviewers  
(see right-pane)
  
  ## Checklist  
 - [X] This PR is linked to one or more issues.  
 - [X] This PR has been tested (attach evidence if possible).  
 - [X] This PR has passed style guidelines.  
