### PR TITLE
Fixes #504 cross-project referencing racing condition...

### DIFF
--- a/tb-gcp-tr/shared-bastion/main.tf
+++ b/tb-gcp-tr/shared-bastion/main.tf
@@ -127,6 +127,9 @@ resource "google_compute_instance_template" "bastion_linux_template" {
     email  = google_service_account.bastion_service_account.email
     scopes = []
   }
+
+  // make sure the project is attached and can see the shared VPC network before referencing one of it's subnetworks
+  depends_on = [google_compute_shared_vpc_service_project.attach_bastion_project]
 }
 
 // Create instance group for the linux bastion
@@ -183,6 +186,9 @@ resource "google_compute_instance_template" "bastion_windows_template" {
   metadata = {
     windows-startup-script-ps1 = "$LocalTempDir = $env:TEMP; $ChromeInstaller = \"ChromeInstaller.exe\"; (new-object System.Net.WebClient).DownloadFile('http://dl.google.com/chrome/install/375.126/chrome_installer.exe', \"$LocalTempDir\\$ChromeInstaller\"); & \"$LocalTempDir\\$ChromeInstaller\" /silent /install;"
   }
+
+  // make sure the project is attached and can see the shared VPC network before referencing one of it's subnetworks
+  depends_on = [google_compute_shared_vpc_service_project.attach_bastion_project]
 }
 
 // Create instance group for the windows bastion


### PR DESCRIPTION
... by making sure the shared-bastion-<random> project is attached to the
shared-networking-<random> project and can see it's shared VPC network
before referencing one of it's subnetworks.

## PR Type  
What kind of change does this PR introduce?  
  
Please check the boxes that applies to this PR.  
  
- [X] Bugfix  
- [ ] Feature  
- [ ] Code style update (formatting, local variables)  
- [ ] Refactoring (no functional changes, no api changes)  
- [ ] Build related changes  
- [ ] CI related changes  
- [ ] Documentation content changes  
- [ ] TranquilityBase application / infrastructure changes  
- [ ] Other... Please describe:  


## Purpose 
Solves the following error which intermittently occurs when deploying Tranquility Base's landing zone.

```
Error: Error creating instance template: googleapi: Error 400: Invalid value for field 'resource.properties.networkInterfaces[0].subnetwork': 'projects/shared-networking-1pw4vr1i/regions/europe-west2/subnetworks/bastion-subnetwork'. Cross-project references for this resource are not allowed., invalid

Error: Error creating instance template: googleapi: Error 400: Invalid value for field 'resource.properties.networkInterfaces[0].subnetwork': 'projects/shared-networking-1pw4vr1i/regions/europe-west2/subnetworks/bastion-subnetwork'. Cross-project references for this resource are not allowed., invalid
```
  
## Reviewers

(see right-pane)
  
  ## Checklist  
 - [X] This PR is linked to one or more issues.  
 - [X] This PR has been tested (attach evidence if possible).  
 - [X] This PR has passed style guidelines.  
