### PR TITLE
issue 493

### DIFF
--- a/tb-gcp-tr/shared-dac/jenkins-master.yaml
+++ b/tb-gcp-tr/shared-dac/jenkins-master.yaml
@@ -10,6 +10,7 @@ parameters:
   replication-type: regional-pd
 volumeBindingMode: WaitForFirstConsumer
 allowedTopologies:
+reclaimPolicy: Retain
 ---
 ### Persistent volume claim ###
 apiVersion: v1
@@ -19,6 +20,7 @@ metadata:
   namespace: cicd
 spec:
   storageClassName: gold
+  volumeMode: Filesystem
   accessModes:
     - ReadWriteOnce
   resources:
@@ -81,9 +83,8 @@ spec:
             runAsUser: 0
           imagePullPolicy: "Always"
           volumeMounts:
-            - mountPath: /var
-              name: jenkins-home
-              subPath: jenkins_home
+            - name: jenkins-home
+              mountPath: /var/jenkins_home
             - name: docker-sock-volume
               mountPath: /var/run/docker.sock
             - name: google-cloud-key


### PR DESCRIPTION
## PR Type  
 the Jenkins persistent disk is reattached after the EC  cluster is completely restarted. i.e. the Node Pool node size is set to 0 and then back to 1 ... jobs, configurations are recovered back after shutting down a node pool.  I have done same for Mysql and redis ....
  
Please check the boxes that applies to this PR.  

- [ ] Bugfix  
- [x ] Feature  
- [ ] Code style update (formatting, local variables)  
- [ ] Refactoring (no functional changes, no api changes)  
- [ ] Build related changes  
- [ ] CI related changes  
- [ ] Documentation content changes  
- [ ] TranquilityBase application / infrastructure changes  
- [ ] Other... Please describe:  


## Purpose 
Describe the problem or feature with a **link** to the issues.    
Also please describe which sections of the code do what and for what reason.  
  
## Reviewers  
@zain-GFT   
  ## Checklist  
 - [ ] This PR is linked to one or more issues.  
 - [ ] This PR has been tested (attach evidence if possible).  
 - [ ] This PR has passed style guidelines.  
