### PR TITLE
issue 493

### DIFF
--- a/tb-gcp-tr/shared-dac/eagle_console.yaml
+++ b/tb-gcp-tr/shared-dac/eagle_console.yaml
@@ -78,9 +78,8 @@ spec:
   claimRef:
     name: mysql-pv-claim
     namespace: ssp
-  resources:
-    requests:
-      storage: 10Gi
+  capacity:
+    storage: 10Gi
   volumeMode: Filesystem
   accessModes:
     - ReadWriteOnce
@@ -98,9 +97,8 @@ spec:
   claimRef:
     name: redis-pv-claim
     namespace: ssp
-  resources:
-    requests:
-      storage: 10Gi
+  capacity:
+    storage: 10Gi
   volumeMode: Filesystem
   accessModes:
     - ReadWriteOnce

--- a/tb-gcp-tr/shared-dac/eagle_console.yaml
+++ b/tb-gcp-tr/shared-dac/eagle_console.yaml
@@ -43,6 +43,7 @@ spec:
   storageClassName: mysql-sc
   accessModes:
     - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
   resources:
     requests:
       storage: 10Gi
@@ -56,6 +57,7 @@ spec:
   storageClassName: redis-sc
   accessModes:
     - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
   resources:
     requests:
       storage: 10Gi

--- a/tb-gcp-tr/shared-dac/eagle_console.yaml
+++ b/tb-gcp-tr/shared-dac/eagle_console.yaml
@@ -34,6 +34,7 @@ parameters:
 volumeBindingMode: WaitForFirstConsumer
 allowedTopologies:
 ---
+##persistent volume claim of mysql
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -41,13 +42,15 @@ metadata:
   namespace: ssp
 spec:
   storageClassName: mysql-sc
+  volumeMode: Filesystem
   accessModes:
     - ReadWriteOnce
-  persistentVolumeReclaimPolicy: Retain
+  volumeName: mysql-pv
   resources:
     requests:
       storage: 10Gi
 ---
+##persistent volume claim of redis
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -55,12 +58,33 @@ metadata:
   namespace: ssp
 spec:
   storageClassName: redis-sc
+  volumeMode: Filesystem
   accessModes:
     - ReadWriteOnce
-  persistentVolumeReclaimPolicy: Retain
+  volumeName: redis-pv
   resources:
     requests:
       storage: 10Gi
+
+---
+##persistent volume of mysql
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: mysql-pv
+  claimRef:
+    name: mysql-pv-claim
+    namespace: ssp
+
+---
+##persistent volume of redis 
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: redis-pv
+  claimRef:
+    name: redis-pv-claim
+    namespace: ssp
 ---
 apiVersion: v1
 kind: Service

--- a/tb-gcp-tr/shared-dac/eagle_console.yaml
+++ b/tb-gcp-tr/shared-dac/eagle_console.yaml
@@ -74,10 +74,10 @@ apiVersion: v1
 kind: PersistentVolume
 metadata:
   name: mysql-pv
+spec:
   claimRef:
     name: mysql-pv-claim
     namespace: ssp
-spec:
   resources:
     requests:
       storage: 10Gi
@@ -94,10 +94,10 @@ apiVersion: v1
 kind: PersistentVolume
 metadata:
   name: redis-pv
+spec: 
   claimRef:
     name: redis-pv-claim
     namespace: ssp
-spec: 
   resources:
     requests:
       storage: 10Gi

--- a/tb-gcp-tr/shared-dac/eagle_console.yaml
+++ b/tb-gcp-tr/shared-dac/eagle_console.yaml
@@ -42,6 +42,15 @@ kind: PersistentVolumeClaim
 metadata:
   name: mysql-pv-claim
   namespace: ssp
+spec:
+  accessModes:
+    - ReadWriteOnce
+  volumeMode: Filesystem
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: mysql-sc
+  volumeName: mysql-pv
 
 ---
 ##persistent VolumeClaim of redis
@@ -50,6 +59,15 @@ kind: PersistentVolumeClaim
 metadata:
   name: redis-pv-claim
   namespace: ssp
+spec:
+  accessModes:
+    - ReadWriteOnce
+  volumeMode: Filesystem
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: redis-sc
+  volumeName: redis-pv
 ---
 ##persistent volume of mysql
 apiVersion: v1
@@ -60,14 +78,14 @@ metadata:
     name: mysql-pv-claim
     namespace: ssp
 spec:
-  storageClassName: mysql-sc
-  volumeMode: Filesystem
-  accessModes:
-    - ReadWriteOnce
-  volumeName: mysql-pv
   resources:
     requests:
       storage: 10Gi
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: mysql-sc
+  volumeName: mysql-pv
   persistentVolumeReclaimPolicy: Retain
 
 ---
@@ -80,14 +98,14 @@ metadata:
     name: redis-pv-claim
     namespace: ssp
 spec: 
-  storageClassName: redis-sc
-  volumeMode: Filesystem
-  accessModes:
-    - ReadWriteOnce
-  volumeName: redis-pv
   resources:
     requests:
       storage: 10Gi
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: redis-sc
+  volumeName: redis-pv
   persistentVolumeReclaimPolicy: Retain
 ---
 apiVersion: v1

--- a/tb-gcp-tr/shared-dac/eagle_console.yaml
+++ b/tb-gcp-tr/shared-dac/eagle_console.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
+##storage class of redis
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
@@ -23,6 +24,7 @@ parameters:
 volumeBindingMode: WaitForFirstConsumer
 allowedTopologies:
 ---
+##storage class of mysql 
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
@@ -34,38 +36,20 @@ parameters:
 volumeBindingMode: WaitForFirstConsumer
 allowedTopologies:
 ---
-##persistent volume claim of mysql
+##persistent VolumeClaim of mysql
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: mysql-pv-claim
   namespace: ssp
-spec:
-  storageClassName: mysql-sc
-  volumeMode: Filesystem
-  accessModes:
-    - ReadWriteOnce
-  volumeName: mysql-pv
-  resources:
-    requests:
-      storage: 10Gi
+
 ---
-##persistent volume claim of redis
+##persistent VolumeClaim of redis
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: redis-pv-claim
   namespace: ssp
-spec:
-  storageClassName: redis-sc
-  volumeMode: Filesystem
-  accessModes:
-    - ReadWriteOnce
-  volumeName: redis-pv
-  resources:
-    requests:
-      storage: 10Gi
-
 ---
 ##persistent volume of mysql
 apiVersion: v1
@@ -75,6 +59,16 @@ metadata:
   claimRef:
     name: mysql-pv-claim
     namespace: ssp
+spec:
+  storageClassName: mysql-sc
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteOnce
+  volumeName: mysql-pv
+  resources:
+    requests:
+      storage: 10Gi
+  persistentVolumeReclaimPolicy: Retain
 
 ---
 ##persistent volume of redis 
@@ -85,6 +79,16 @@ metadata:
   claimRef:
     name: redis-pv-claim
     namespace: ssp
+spec: 
+  storageClassName: redis-sc
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteOnce
+  volumeName: redis-pv
+  resources:
+    requests:
+      storage: 10Gi
+  persistentVolumeReclaimPolicy: Retain
 ---
 apiVersion: v1
 kind: Service

--- a/tb-gcp-tr/shared-dac/jenkins-master.yaml
+++ b/tb-gcp-tr/shared-dac/jenkins-master.yaml
@@ -22,10 +22,19 @@ spec:
   volumeMode: Filesystem
   accessModes:
     - ReadWriteOnce
-  persistentVolumeReclaimPolicy: Retain
+  volumeName: jenkins-master-pv
   resources:
     requests:
       storage: 50Gi
+---
+##persistent volume 
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: jenkins-master-pv
+  claimRef:
+    name: jenkins-master-pv-claim
+    namespace: cicd
 ---
 ### Jenkins Service ###
 apiVersion: v1

--- a/tb-gcp-tr/shared-dac/jenkins-master.yaml
+++ b/tb-gcp-tr/shared-dac/jenkins-master.yaml
@@ -32,10 +32,10 @@ apiVersion: v1
 kind: PersistentVolume
 metadata:
   name: jenkins-master-pv
+spec:
   claimRef:
     name: jenkins-master-pv-claim
     namespace: cicd
-spec:
   resources:
     requests:
       storage: 50Gi

--- a/tb-gcp-tr/shared-dac/jenkins-master.yaml
+++ b/tb-gcp-tr/shared-dac/jenkins-master.yaml
@@ -11,7 +11,7 @@ parameters:
 volumeBindingMode: WaitForFirstConsumer
 allowedTopologies:
 ---
-### Persistent volume claim ###
+### Persistent VolumeClaim of jenkins###
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -27,7 +27,7 @@ spec:
   storageClassName: gold
   volumeName: jenkins-master-pv
 ---
-##persistent volume 
+##persistent volume of jenkins ## 
 apiVersion: v1
 kind: PersistentVolume
 metadata:
@@ -36,9 +36,8 @@ spec:
   claimRef:
     name: jenkins-master-pv-claim
     namespace: cicd
-  resources:
-    requests:
-      storage: 50Gi
+  capacity:
+    storage: 50Gi
   volumeMode: Filesystem
   accessModes:
     - ReadWriteOnce

--- a/tb-gcp-tr/shared-dac/jenkins-master.yaml
+++ b/tb-gcp-tr/shared-dac/jenkins-master.yaml
@@ -19,8 +19,10 @@ metadata:
   namespace: cicd
 spec:
   storageClassName: gold
+  volumeMode: Filesystem
   accessModes:
     - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
   resources:
     requests:
       storage: 50Gi
@@ -81,9 +83,8 @@ spec:
             runAsUser: 0
           imagePullPolicy: "Always"
           volumeMounts:
-            - mountPath: /var
-              name: jenkins-home
-              subPath: jenkins_home
+            - name: jenkins-home
+              mountPath: /var/jenkins_home
             - name: docker-sock-volume
               mountPath: /var/run/docker.sock
             - name: google-cloud-key

--- a/tb-gcp-tr/shared-dac/jenkins-master.yaml
+++ b/tb-gcp-tr/shared-dac/jenkins-master.yaml
@@ -17,15 +17,6 @@ kind: PersistentVolumeClaim
 metadata:
   name: jenkins-master-pv-claim
   namespace: cicd
-spec:
-  storageClassName: gold
-  volumeMode: Filesystem
-  accessModes:
-    - ReadWriteOnce
-  volumeName: jenkins-master-pv
-  resources:
-    requests:
-      storage: 50Gi
 ---
 ##persistent volume 
 apiVersion: v1
@@ -35,6 +26,16 @@ metadata:
   claimRef:
     name: jenkins-master-pv-claim
     namespace: cicd
+spec:
+  resources:
+    requests:
+      storage: 50Gi
+  persistentVolumeReclaimPolicy: Retain
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: gold
+  volumeName: jenkins-master-pv
 ---
 ### Jenkins Service ###
 apiVersion: v1

--- a/tb-gcp-tr/shared-dac/jenkins-master.yaml
+++ b/tb-gcp-tr/shared-dac/jenkins-master.yaml
@@ -17,6 +17,15 @@ kind: PersistentVolumeClaim
 metadata:
   name: jenkins-master-pv-claim
   namespace: cicd
+spec:
+  accessModes:
+    - ReadWriteOnce
+  volumeMode: Filesystem
+  resources:
+    requests:
+      storage: 50Gi
+  storageClassName: gold
+  volumeName: jenkins-master-pv
 ---
 ##persistent volume 
 apiVersion: v1
@@ -30,12 +39,11 @@ spec:
   resources:
     requests:
       storage: 50Gi
-  persistentVolumeReclaimPolicy: Retain
   volumeMode: Filesystem
   accessModes:
     - ReadWriteOnce
   storageClassName: gold
-  volumeName: jenkins-master-pv
+  persistentVolumeReclaimPolicy: Retain
 ---
 ### Jenkins Service ###
 apiVersion: v1


### PR DESCRIPTION
## PR Type  
the Jenkins persistent disk is reattached after the EC cluster is completely restarted. i.e. the Node Pool node size is set to 0 and then back to 1 ... jobs, configurations are recovered back after shutting down a node pool. I have done same for Mysql and redis ....
  
Please check the boxes that applies to this PR.  
  
- [ ] Bugfix  
- [x ] Feature  
- [ ] Code style update (formatting, local variables)  
- [ ] Refactoring (no functional changes, no api changes)  
- [ ] Build related changes  
- [ ] CI related changes  
- [ ] Documentation content changes  
- [ ] TranquilityBase application / infrastructure changes  
- [ ] Other... Please describe:  


## Purpose 
please refer above 

## Reviewers  
@rjmco 
@zain-GFT 
@sunderhill-gft 

  ## Checklist  
 - [ ] This PR is linked to one or more issues.  
 - [ ] This PR has been tested (attach evidence if possible).  
 - [ ] This PR has passed style guidelines.  
