### PR TITLE
Refixes #504: one instance template was missed

### DIFF
--- a/tb-gcp-tr/shared-bastion/main.tf
+++ b/tb-gcp-tr/shared-bastion/main.tf
@@ -225,6 +225,8 @@ resource "google_compute_instance_template" "squid_proxy_template" {
 
   metadata_startup_script = file("${path.module}/squid_startup.sh")
 
+  // make sure the project is attached and can see the shared VPC network before referencing one of it's subnetworks
+  depends_on = [google_compute_shared_vpc_service_project.attach_bastion_project]
 }
 
 // Create instance group for the squid proxy


### PR DESCRIPTION
... applies the same fix as 36a363d to the squid_proxy_template as well

## PR Type  
  
Please check the boxes that applies to this PR.  
  
- [X] Bugfix  
- [ ] Feature  
- [ ] Code style update (formatting, local variables)  
- [ ] Refactoring (no functional changes, no api changes)  
- [ ] Build related changes  
- [ ] CI related changes  
- [ ] Documentation content changes  
- [ ] TranquilityBase application / infrastructure changes  
- [ ] Other... Please describe:  


## Purpose 

Fixes #504 once again as one of the instance templates was missed on my 1st attempt at this (#507). Hopefully this is the last that we will see of the error logged on the issue.
  
## Reviewers  
(see right-pane)
  
  ## Checklist  
 - [X] This PR is linked to one or more issues.  
 - [X] This PR has been tested (attach evidence if possible).  
 - [X] This PR has passed style guidelines.  
