### PR TITLE
Issue 441

### DIFF
--- a/tb-gcp-tr/shared-dac/jenkins-master.yaml
+++ b/tb-gcp-tr/shared-dac/jenkins-master.yaml
@@ -31,12 +31,9 @@ kind: Service
 metadata:
   name: jenkins-master-svc
   namespace: cicd
-  annotations:
-    cloud.google.com/load-balancer-type: "Internal"
   labels:
     app: jenkins-master
 spec:
-  type: LoadBalancer
   ports:
     - port: 80
       targetPort: 8080
@@ -73,6 +70,7 @@ spec:
       containers:
         - name: jenkins-master
           image: gcr.io/tranquility-base-images/tb-jenkins_latest:landingzone
+          args: ["--prefix=/jenkins-service"]
           securityContext:
             privileged: true
             runAsUser: 0
@@ -126,7 +124,7 @@ spec:
     istio: private-ingressgateway  # use istio default controller
   servers:
     - port:
-        number: 8080
+        number: 80
         name: http
         protocol: HTTP
       hosts:
@@ -136,7 +134,7 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
-  name: jenkinsservice
+  name: jenkins-master-svc
   namespace: cicd
 spec:
   hosts:
@@ -144,11 +142,14 @@ spec:
   gateways:
     - jenkins-gateway
   http:
+    - match:
+        - uri:
+            prefix: /jenkins-service
     - route:
         - destination:
-            host: jenkins-master
+            host: jenkins-master-svc.cicd.svc.cluster.local
             port:
-              number: 8080
+              number: 80
       corsPolicy:
         allowOrigin:
           - "*"
@@ -161,3 +162,18 @@ spec:
           - DELETE
         allowHeaders:
           - "*"
+---
+### Jenkins Destination Rule ###
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: jenkins-master-svc
+  namespace: cicd
+  annotations:
+    cloud.google.com/load-balancer-type: "Internal"
+spec:
+  host: jenkins-master-svc.cicd.svc.cluster.local
+  trafficPolicy:
+    loadBalancer:
+      simple: LEAST_CONN
+

--- a/tb-gcp-tr/shared-dac/jenkins-master.yaml
+++ b/tb-gcp-tr/shared-dac/jenkins-master.yaml
@@ -138,30 +138,30 @@ metadata:
   namespace: cicd
 spec:
   hosts:
-    - "*"
+  - "*"
   gateways:
-    - jenkins-gateway
+  - jenkins-gateway
   http:
-    - match:
-        - uri:
-            prefix: /jenkins-service
-    - route:
-        - destination:
-            host: jenkins-master-svc.cicd.svc.cluster.local
-            port:
-              number: 80
-      corsPolicy:
-        allowOrigin:
-          - "*"
-        allowMethods:
-          - POST
-          - GET
-          - OPTIONS
-          - PUT
-          - PATCH
-          - DELETE
-        allowHeaders:
-          - "*"
+  - match:
+    - uri:
+        prefix: /jenkins-service
+    route:
+    - destination:
+        host: jenkins-master-svc.cicd.svc.cluster.local
+        port:
+          number: 80
+    corsPolicy:
+      allowOrigin:
+        - "*"
+      allowMethods:
+        - POST
+        - GET
+        - OPTIONS
+        - PUT
+        - PATCH
+        - DELETE
+      allowHeaders:
+        - "*"
 ---
 ### Jenkins Destination Rule ###
 apiVersion: networking.istio.io/v1alpha3
@@ -176,4 +176,3 @@ spec:
   trafficPolicy:
     loadBalancer:
       simple: LEAST_CONN
-


### PR DESCRIPTION
## PR Type  

1. This PR Create a separate gateway for jenkins in the cicd namespace

2. Also Creates a separate virtualservice and destination rule for jenkins, so that when you hit the private gateway endpoint with the /jenkins-service prefix, it should bring up the jenkins service

3. This PR also changes the jenkins kubernetes service config from a loadbalancer to a clusterip.

  
Please check the boxes that applies to this PR.  
  
- [ ] Namespace updates


## Purpose 
Jenkins service can now be accessed using http://eagle-console.tranquilitybase.internal./jenkins-service

This PR prevents the need for jenkins service having to be accessed through a separate DNS name.
  
## Reviewers  

  ## Checklist  
 - [ ] This PR is linked to one or more issues.  
 - [ ] This PR has been tested (attach evidence if possible).  
 - [ ] This PR has passed style guidelines.  
