### PR TITLE
Solves #527 bucket_policy_only deprecation warning

### DIFF
--- a/tb-gcp-tr/landingZone/no-itop/main.tf
+++ b/tb-gcp-tr/landingZone/no-itop/main.tf
@@ -87,7 +87,7 @@ module "shared_projects" {
 }
 
 module "gcs_bucket_logging" {
-  source = "github.com/tranquilitybase-io/terraform-google-cloud-storage.git//modules/simple_bucket?ref=v1.6.0-logging"
+  source = "github.com/tranquilitybase-io/terraform-google-cloud-storage.git//modules/simple_bucket?ref=logging-v3"
 
   name        = "${var.gcs_logs_bucket_prefix}-${var.tb_discriminator}"
   project_id  = module.shared_projects.shared_telemetry_id


### PR DESCRIPTION
by bumping terraform-google-cloud-storage to the logging-v3 head

## PR Type  
What kind of change does this PR introduce?  
  
Please check the boxes that applies to this PR.  
  
- [X] Bugfix  
- [ ] Feature  
- [ ] Code style update (formatting, local variables)  
- [X] Refactoring (no functional changes, no api changes)  
- [ ] Build related changes  
- [ ] CI related changes  
- [ ] Documentation content changes  
- [ ] TranquilityBase application / infrastructure changes  
- [ ] Other... Please describe:  


## Purpose 

As described on #527, this PR fixes the following deprecation warning:

> ```
> Step #0 - "Package image":     googlecompute: Warning: Attribute is deprecated
> Step #0 - "Package image":     googlecompute:
> Step #0 - "Package image":     googlecompute:   on .terraform/modules/gcs_bucket_logging/modules/simple_bucket/main.tf line 22, in resource "google_storage_bucket" "bucket":
> Step #0 - "Package image":     googlecompute:   22:   bucket_policy_only = var.bucket_policy_only
> Step #0 - "Package image":     googlecompute: 
> Step #0 - "Package image":     googlecompute: Please use the uniform_bucket_level_access as this field has been renamed by
> Step #0 - "Package image":     googlecompute: Google.
> ```
  
## Reviewers  

(see right-pane)
  
  ## Checklist  
 - [X] This PR is linked to one or more issues.  
 - [X] This PR has been tested (attach evidence if possible).  
 - [X] This PR has passed style guidelines.  
