### PR TITLE
Fixes Issue-321 (#531) Add A record to Cloud DNS for all compute instances

### DIFF
--- a/tb-gcp-deploy/pack/packer-no-itop.json
+++ b/tb-gcp-deploy/pack/packer-no-itop.json
@@ -105,6 +105,11 @@
       "source": "{{user `tb_repos_root_path`}}/tb-gcp-tr/shared-vpc",
       "destination": "tb-gcp-tr/"
     },
+	{
+      "type": "file",
+      "source": "{{user `tb_repos_root_path`}}/tb-gcp-tr/dns-instances",
+      "destination": "tb-gcp-tr/"
+    },
     {
       "type": "file",
       "source": "{{user `tb_repos_root_path`}}/tb-gcp-tr/single-bastion",

--- a/tb-gcp-tr/dns-instances/main.tf
+++ b/tb-gcp-tr/dns-instances/main.tf
@@ -1,0 +1,59 @@
+data "google_compute_instance" "linux_instances" {
+  zone = "europe-west1-b"
+  self_link = element(var.linux_instances, 0)
+}
+
+data "google_compute_instance" "windows_instances" {
+  zone = "europe-west1-b"
+  self_link = element(var.windows_instances, 0)
+}
+
+data "google_compute_instance" "squid_proxy_instances" {
+  zone = "europe-west1-b"
+  self_link = element(var.squid_proxy_instances, 0)
+}
+
+resource "google_dns_record_set" "linux_instance_dns" {
+  project = var.shared_networking
+  name = "tb-linux-bastion.${var.private_dns_domain_name}"
+  type = "A"
+  ttl  = 300
+
+  managed_zone = var.private_dns_name
+
+  rrdatas = [data.google_compute_instance.linux_instances.network_interface[0].network_ip]
+
+    depends_on = [
+    data.google_compute_instance.linux_instances, var.private_dns_name, var.private_dns_domain_name
+  ]
+}
+
+resource "google_dns_record_set" "windows_instance_dns" {
+  project = var.shared_networking
+  name = "tb-windows-bastion.${var.private_dns_domain_name}"
+  type = "A"
+  ttl  = 300
+
+  managed_zone = var.private_dns_name
+
+  rrdatas = [data.google_compute_instance.windows_instances.network_interface[0].network_ip]
+
+    depends_on = [
+    data.google_compute_instance.windows_instances, var.private_dns_name, var.private_dns_domain_name
+  ]
+}
+
+resource "google_dns_record_set" "squid_proxy_dns" {
+  project = var.shared_networking
+  name = "tb-squid-proxy.${var.private_dns_domain_name}"
+  type = "A"
+  ttl  = 300
+
+  managed_zone = var.private_dns_name
+
+  rrdatas = [data.google_compute_instance.squid_proxy_instances.network_interface[0].network_ip]
+
+    depends_on = [
+    data.google_compute_instance.squid_proxy_instances, var.private_dns_name, var.private_dns_domain_name
+  ]
+}

--- a/tb-gcp-tr/dns-instances/variables.tf
+++ b/tb-gcp-tr/dns-instances/variables.tf
@@ -1,0 +1,20 @@
+variable "linux_instances" {
+  type    = list(string)
+}
+
+variable "windows_instances" {
+  type    = list(string)
+}
+
+variable "squid_proxy_instances" {
+  type    = list(string)
+}
+
+variable "zone" {}
+
+variable "shared_networking" {}
+
+variable "private_dns_domain_name" {}
+
+variable "private_dns_name" {}
+

--- a/tb-gcp-tr/landingZone/no-itop/main.tf
+++ b/tb-gcp-tr/landingZone/no-itop/main.tf
@@ -167,6 +167,20 @@ module "bastion-security" {
   shared_networking_id          = module.shared_projects.shared_networking_id
   root_id                       = var.root_id
   shared_bastion_project_number = module.shared_projects.shared_bastion_project_number
+  depends_on = [module.shared-vpc]
+}
+
+module "dns-instances" {
+  source = "../../dns-instances"
+
+  linux_instances = module.bastion-security.linux_bastion_instances
+  private_dns_domain_name = module.shared-vpc.dns_domain_name
+  private_dns_name = module.shared-vpc.dns_name
+  squid_proxy_instances = module.bastion-security.squid_proxy_instances
+  windows_instances = module.bastion-security.windows_bastion_instances
+  zone = var.region_zone
+  shared_networking = module.shared_projects.shared_networking_id
+  depends_on = [module.bastion-security, module.shared-vpc]
 }
 
 module "logging_export" {

--- a/tb-gcp-tr/shared-bastion/data_sources.tf
+++ b/tb-gcp-tr/shared-bastion/data_sources.tf
@@ -1,0 +1,17 @@
+// Gets the linux bastion instance group from the linux bastion instance group manager
+data "google_compute_instance_group" "linux_bastion_instance_group" {
+  depends_on = [time_sleep.linux_wait_30_seconds]
+  self_link = google_compute_instance_group_manager.linux_bastion_group.instance_group
+}
+
+// Gets the windows bastion instance group from the windows bastion instance group manager
+data "google_compute_instance_group" "windows_bastion_instance_group" {
+  depends_on = [time_sleep.windows_wait_30_seconds]
+  self_link = google_compute_instance_group_manager.windows_bastion_group.instance_group
+}
+
+// Gets the squid proxy instance group from the squid proxy instance group manager
+data "google_compute_instance_group" "squid_proxy_instance_group" {
+  depends_on = [time_sleep.squid_wait_30_seconds]
+  self_link = google_compute_instance_group_manager.squid_proxy_group.instance_group
+}

--- a/tb-gcp-tr/shared-bastion/main.tf
+++ b/tb-gcp-tr/shared-bastion/main.tf
@@ -246,6 +246,24 @@ resource "google_compute_instance_group_manager" "squid_proxy_group" {
   depends_on = [google_compute_subnetwork_iam_binding.bastion_subnet_permission, google_service_account.bastion_service_account]
 }
 
+resource "time_sleep" "linux_wait_30_seconds" {
+  depends_on = [google_compute_instance_group_manager.linux_bastion_group]
+
+  create_duration = "80s"
+}
+
+resource "time_sleep" "windows_wait_30_seconds" {
+  depends_on = [google_compute_instance_group_manager.windows_bastion_group]
+
+  create_duration = "80s"
+}
+
+resource "time_sleep" "squid_wait_30_seconds" {
+  depends_on = [google_compute_instance_group_manager.squid_proxy_group]
+
+  create_duration = "80s"
+}
+
 resource "null_resource" "start-iap-tunnel" {
 
   provisioner "local-exec" {

--- a/tb-gcp-tr/shared-bastion/outputs.tf
+++ b/tb-gcp-tr/shared-bastion/outputs.tf
@@ -1,0 +1,17 @@
+// outputs the set of linux bastion instances from the linux bastion instance group
+output linux_bastion_instances {
+  description = "The set of linux bastion instances"
+  value = tolist(data.google_compute_instance_group.linux_bastion_instance_group.instances)
+}
+
+// outputs the set of windows bastion instances from the windows bastion instance group
+output windows_bastion_instances {
+  description = "The set of windows bastion instances"
+  value = tolist(data.google_compute_instance_group.windows_bastion_instance_group.instances)
+}
+
+// outputs the set of squid proxy instances from the squid proxy instance group
+output squid_proxy_instances {
+  description = "The set of squid proxy instances"
+  value = tolist(data.google_compute_instance_group.squid_proxy_instance_group.instances)
+}

--- a/tb-gcp-tr/shared-vpc/outputs.tf
+++ b/tb-gcp-tr/shared-vpc/outputs.tf
@@ -33,3 +33,11 @@ output "bastion_subnetwork_name" {
 output "nat_static_ip" {
   value = google_compute_address.static.address
 }
+
+output "dns_name" {
+  value = google_dns_managed_zone.private-zone.name
+}
+
+output "dns_domain_name" {
+  value = google_dns_managed_zone.private-zone.dns_name
+}


### PR DESCRIPTION
## PR Type  
What kind of change does this PR introduce?  
Adds DNS A records for the instances in the shared-bastion project. These A records are added to the "private-shared" DNS zone.

![Screenshot (34)](https://user-images.githubusercontent.com/64900858/96157215-ed94b400-0f09-11eb-8846-55a5e85c350f.png)

  
Please check the boxes that applies to this PR.  
  
- [ ] Feature  



## Purpose 
https://github.com/tranquilitybase-io/tb-gcp/issues/321

Allow for a known DNS zone to be used for all records rather than relying on google cloud's internal DNS.
  
## Reviewers  

  
  ## Checklist  
 - [ ] This PR is linked to one or more issues.  
 - [ ] This PR has been tested (attach evidence if possible).  
 - [ ] This PR has passed style guidelines.  
