### PR TITLE
Issue 508 - Add 'dac user' to Jenkins so that DAC can monitor running jobs on Jenkins 

### DIFF
--- a/tb-gcp-tr/dac-secret/main.tf
+++ b/tb-gcp-tr/dac-secret/main.tf
@@ -1,0 +1,41 @@
+resource "random_password" "password" {
+  length = 10
+  special = true
+  override_special = "_%@"
+}
+
+## Creates dac username and password in the cicd namespace ##
+
+resource "null_resource" "kubernetes_dac_secret_cicd" {
+  triggers = {
+    content = var.content
+    k8_name = var.context_name
+  }
+
+  provisioner "local-exec" {
+    command = "echo 'kubectl --context=${var.context_name} create secret generic dac-user-pass -n cicd --from-literal=username=dac --from-literal=password='${random_password.password.result}' --type=kubernetes.io/basic-auth' | tee -a /opt/tb/repo/tb-gcp-tr/landingZone/kube.sh"
+  }
+
+  provisioner "local-exec" {
+    command = "echo 'kubectl --context=${self.triggers.k8_name} delete secret dac-user-pass' -n cicd | tee -a /opt/tb/repo/tb-gcp-tr/landingZone/kube.sh"
+    when    = destroy
+  }
+}
+
+## Creates dac username and password in the ssp namespace ##
+
+resource "null_resource" "kubernetes_dac_secret_ssp" {
+  triggers = {
+    content = var.content
+    k8_name = var.context_name
+  }
+
+  provisioner "local-exec" {
+    command = "echo 'kubectl --context=${var.context_name} create secret generic dac-user-pass -n ssp --from-literal=username=dac --from-literal=password='${random_password.password.result}' --type=kubernetes.io/basic-auth' | tee -a /opt/tb/repo/tb-gcp-tr/landingZone/kube.sh"
+  }
+
+  provisioner "local-exec" {
+    command = "echo 'kubectl --context=${self.triggers.k8_name} delete secret dac-user-pass' -n ssp | tee -a /opt/tb/repo/tb-gcp-tr/landingZone/kube.sh"
+    when    = destroy
+  }
+}

--- a/tb-gcp-tr/dac-secret/main.tf
+++ b/tb-gcp-tr/dac-secret/main.tf
@@ -4,7 +4,7 @@ resource "random_password" "password" {
   override_special = "_%@"
 }
 
-## Creates dac username and password in the cicd namespace ##
+## Creates Dac username and password in the cicd namespace ##
 
 resource "null_resource" "kubernetes_dac_secret_cicd" {
   triggers = {
@@ -22,7 +22,7 @@ resource "null_resource" "kubernetes_dac_secret_cicd" {
   }
 }
 
-## Creates dac username and password in the ssp namespace ##
+## Creates Dac username and password in the ssp namespace ##
 
 resource "null_resource" "kubernetes_dac_secret_ssp" {
   triggers = {

--- a/tb-gcp-tr/dac-secret/variables.tf
+++ b/tb-gcp-tr/dac-secret/variables.tf
@@ -1,0 +1,7 @@
+variable "content" {
+  description = "Content for the trigger"
+}
+
+variable "context_name" {
+  description = "GKE context name stored into ~/.kube/config"
+}

--- a/tb-gcp-tr/dac-secret/variables.tf
+++ b/tb-gcp-tr/dac-secret/variables.tf
@@ -1,5 +1,5 @@
 variable "content" {
-  description = "Content for the Trigger"
+  description = "Content for the trigger"
 }
 
 variable "context_name" {

--- a/tb-gcp-tr/dac-secret/variables.tf
+++ b/tb-gcp-tr/dac-secret/variables.tf
@@ -1,5 +1,5 @@
 variable "content" {
-  description = "Content for the trigger"
+  description = "Content for the Trigger"
 }
 
 variable "context_name" {

--- a/tb-gcp-tr/landingZone/no-itop/main.tf
+++ b/tb-gcp-tr/landingZone/no-itop/main.tf
@@ -183,6 +183,14 @@ module "dns-instances" {
   depends_on = [module.bastion-security, module.shared-vpc]
 }
 
+module "dac-secret" {
+  source = "../../dac-secret"
+
+  content = module.SharedServices_namespace_creation.id
+  context_name = module.k8s-ec_context.context_name
+  depends_on = [module.SharedServices_namespace_creation]
+}
+
 module "logging_export" {
   source                        = "../../logging-export"
   tb_discriminator              = var.tb_discriminator
@@ -314,6 +322,7 @@ module "SharedServices_jenkinsmaster_creation" {
   cluster_context   = module.k8s-ec_context.context_name
   # Jenkins Deployment depends on the ec-service-account secret creation
   dependency_var = null_resource.kubernetes_jenkins_service_account_key_secret.id
+  depends_on = [module.dac-secret]
 }
 
 module "SharedServices_configuration_file" {
@@ -330,6 +339,7 @@ module "SharedServices_ec" {
   k8s_template_file = var.eagle_console_yaml_path
   cluster_context   = module.k8s-ec_context.context_name
   dependency_var    = module.SharedServices_configuration_file.id
+  depends_on = [module.dac-secret]
 }
 
 resource "null_resource" "get_endpoint" {

--- a/tb-gcp-tr/shared-dac/eagle_console.yaml
+++ b/tb-gcp-tr/shared-dac/eagle_console.yaml
@@ -252,6 +252,16 @@ spec:
               value: 'houstonservice:80'
             - name: JENKINS_BASE_URL
               value: 'eagle-console.tranquilitybase-demo.io/jenkins-service'
+            - name: DAC_USER
+              valueFrom:
+                secretKeyRef:
+                  name: dac-user-pass
+                  key: username
+            - name: DAC_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: dac-user-pass
+                  key: password
 
         - name: gcpdacworker
           image: gcr.io/tranquility-base-images/tb-gcp-dac:landingzone
@@ -285,6 +295,16 @@ spec:
               value: 'houstonservice:80'
             - name: JENKINS_BASE_URL
               value: 'eagle-console.tranquilitybase-demo.io/jenkins-service'
+            - name: DAC_USER
+              valueFrom:
+                secretKeyRef:
+                  name: dac-user-pass
+                  key: username
+            - name: DAC_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: dac-user-pass
+                  key: password
 
       volumes:
         - name: config-volume

--- a/tb-gcp-tr/shared-dac/eagle_console.yaml
+++ b/tb-gcp-tr/shared-dac/eagle_console.yaml
@@ -252,12 +252,12 @@ spec:
               value: 'houstonservice:80'
             - name: JENKINS_BASE_URL
               value: 'eagle-console.tranquilitybase-demo.io/jenkins-service'
-            - name: DAC_USER
+            - name: DAC_JENKINS_USER
               valueFrom:
                 secretKeyRef:
                   name: dac-user-pass
                   key: username
-            - name: DAC_PASSWORD
+            - name: DAC_JENKINS_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: dac-user-pass
@@ -295,12 +295,12 @@ spec:
               value: 'houstonservice:80'
             - name: JENKINS_BASE_URL
               value: 'eagle-console.tranquilitybase-demo.io/jenkins-service'
-            - name: DAC_USER
+            - name: DAC_JENKINS_USER
               valueFrom:
                 secretKeyRef:
                   name: dac-user-pass
                   key: username
-            - name: DAC_PASSWORD
+            - name: DAC_JENKINS_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: dac-user-pass

--- a/tb-gcp-tr/shared-dac/jenkins-master.yaml
+++ b/tb-gcp-tr/shared-dac/jenkins-master.yaml
@@ -86,12 +86,12 @@ spec:
           env:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /var/secrets/google/ec-service-account-config.json
-            - name: DAC_USER
+            - name: DAC_JENKINS_USER
               valueFrom:
                 secretKeyRef:
                   name: dac-user-pass
                   key: username
-            - name: DAC_PASSWORD
+            - name: DAC_JENKINS_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: dac-user-pass

--- a/tb-gcp-tr/shared-dac/jenkins-master.yaml
+++ b/tb-gcp-tr/shared-dac/jenkins-master.yaml
@@ -86,6 +86,16 @@ spec:
           env:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /var/secrets/google/ec-service-account-config.json
+              name: DAC_USER
+              valueFrom:
+                secretKeyRef:
+                  name: dac-user-pass
+                  key: username
+              name: DAC_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: dac-user-pass
+                  key: password
           resources:
             requests:
               memory: "1024Mi"

--- a/tb-gcp-tr/shared-dac/jenkins-master.yaml
+++ b/tb-gcp-tr/shared-dac/jenkins-master.yaml
@@ -70,7 +70,7 @@ spec:
     spec:
       containers:
         - name: jenkins-master
-          image: gcr.io/tranquility-base-images/tb-jenkins_latest:landingzonee
+          image: gcr.io/tranquility-base-images/tb-jenkins_latest:landingzone
           args: ["--prefix=/jenkins-service"]
           securityContext:
             privileged: true

--- a/tb-gcp-tr/shared-dac/jenkins-master.yaml
+++ b/tb-gcp-tr/shared-dac/jenkins-master.yaml
@@ -70,7 +70,7 @@ spec:
     spec:
       containers:
         - name: jenkins-master
-          image: gcr.io/tranquility-base-images/tb-jenkins_latest:landingzone
+          image: gcr.io/tranquility-base-images/tb-jenkins_latest:landingzonee
           args: ["--prefix=/jenkins-service"]
           securityContext:
             privileged: true

--- a/tb-gcp-tr/shared-dac/jenkins-master.yaml
+++ b/tb-gcp-tr/shared-dac/jenkins-master.yaml
@@ -86,12 +86,12 @@ spec:
           env:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /var/secrets/google/ec-service-account-config.json
-              name: DAC_USER
+            - name: DAC_USER
               valueFrom:
                 secretKeyRef:
                   name: dac-user-pass
                   key: username
-              name: DAC_PASSWORD
+            - name: DAC_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: dac-user-pass


### PR DESCRIPTION
## PR Type  
This PR creates 2 secrets within the EC cluster:

dac-user-pass in the ssp namespace.
dac-user-pass in the cicd namespace.

This secret contains the credentials for the DAC user. The password for this user is generated randomly on every deployment using the random password terraform resource.

These secrets are then integrated into the kubernetes manifest files with the jenkins and dac container's pulling the values from these secrets and storing it as environment variables.

Please check the boxes that applies to this PR.


- [ ] Feature  

## Purpose 
To allow the 'dac user' (not an admin) to Jenkins so that DAC can monitor running jobs on Jenkins.

To also prevent the need for hardcoding the Dac user credentials in various places.
  
## Reviewers  
 - **Reviewer A** please review this part.  
 - **Review B** please review this part.  
  
  ## Checklist  
 - [ ] This PR is linked to one or more issues.  
 - [ ] This PR has been tested (attach evidence if possible).  
 - [ ] This PR has passed style guidelines.  
