### PR TITLE
Issue 552 - Provide the node pools with full access scope for all Google Cloud Services as per best practises

### DIFF
--- a/tb-gcp-tr/kubernetes-cluster-creation/variables.tf
+++ b/tb-gcp-tr/kubernetes-cluster-creation/variables.tf
@@ -116,8 +116,7 @@ variable "cluster_node_disk_size" {
 variable "cluster_oauth_scopes" {
   type = list(string)
   default = [
-    "https://www.googleapis.com/auth/cloud-platform",
-    "https://www.googleapis.com/auth/projecthosting"
+    "https://www.googleapis.com/auth/cloud-platform"
   ]
 }
 

--- a/tb-gcp-tr/kubernetes-cluster-creation/variables.tf
+++ b/tb-gcp-tr/kubernetes-cluster-creation/variables.tf
@@ -116,7 +116,8 @@ variable "cluster_node_disk_size" {
 variable "cluster_oauth_scopes" {
   type = list(string)
   default = [
-    "https://www.googleapis.com/auth/cloud-platform"
+    "https://www.googleapis.com/auth/cloud-platform",
+    "https://www.googleapis.com/auth/projecthosting"
   ]
 }
 

--- a/tb-gcp-tr/kubernetes-cluster-creation/variables.tf
+++ b/tb-gcp-tr/kubernetes-cluster-creation/variables.tf
@@ -116,11 +116,7 @@ variable "cluster_node_disk_size" {
 variable "cluster_oauth_scopes" {
   type = list(string)
   default = [
-    "compute-rw",
-    "storage-ro",
-    "logging-write",
-    "monitoring",
-    "https://www.googleapis.com/auth/userinfo.email",
+    "https://www.googleapis.com/auth/cloud-platform"
   ]
 }
 

--- a/tb-gcp-tr/landingZone/no-itop/main.tf
+++ b/tb-gcp-tr/landingZone/no-itop/main.tf
@@ -230,6 +230,7 @@ module "gke-ec" {
   )
   cluster_min_master_version        = var.cluster_ec_min_master_version
   cluster_default_max_pods_per_node = var.cluster_ec_default_max_pods_per_node
+  cluster_oauth_scopes = var.cluster_oauth_scopes
 
   apis_dependency          = module.apis_activation.all_apis_enabled
   shared_vpc_dependency    = module.shared-vpc.gke_subnetwork_ids

--- a/tb-gcp-tr/landingZone/no-itop/variables.tf
+++ b/tb-gcp-tr/landingZone/no-itop/variables.tf
@@ -241,6 +241,13 @@ variable "cluster_opt_name" {
   type        = string
 }
 
+variable "cluster_oauth_scopes" {
+  type = list(string)
+  default = [
+    "https://www.googleapis.com/auth/cloud-platform"
+  ]
+}
+
 variable "cluster_ec_pool_name" {
   default     = "gke-ec-node-pool"
   description = "The cluster pool name"

--- a/tb-gcp-tr/landingZone/no-itop/variables.tf
+++ b/tb-gcp-tr/landingZone/no-itop/variables.tf
@@ -244,8 +244,7 @@ variable "cluster_opt_name" {
 variable "cluster_oauth_scopes" {
   type = list(string)
   default = [
-    "https://www.googleapis.com/auth/cloud-platform",
-    "https://www.googleapis.com/auth/projecthosting"
+    "https://www.googleapis.com/auth/cloud-platform"
   ]
 }
 

--- a/tb-gcp-tr/landingZone/no-itop/variables.tf
+++ b/tb-gcp-tr/landingZone/no-itop/variables.tf
@@ -244,7 +244,8 @@ variable "cluster_opt_name" {
 variable "cluster_oauth_scopes" {
   type = list(string)
   default = [
-    "https://www.googleapis.com/auth/cloud-platform"
+    "https://www.googleapis.com/auth/cloud-platform",
+    "https://www.googleapis.com/auth/projecthosting"
   ]
 }
 


### PR DESCRIPTION
## PR Type  
What kind of change does this PR introduce?  

Provides the node pools in the k8 cluster with full access to all Google Cloud Services as recommended per Google's best practises. 
  
Please check the boxes that applies to this PR.  
   
- [ ] Feature  



## Purpose 
  https://github.com/tranquilitybase-io/tb-gcp/issues/552
  
## Reviewers  
 - **Reviewer A** please review this part.  
 - **Review B** please review this part.  
  
  ## Checklist  
 - [ ] This PR is linked to one or more issues.  
 - [ ] This PR has been tested (attach evidence if possible).  
 - [ ] This PR has passed style guidelines.  
