### PR TITLE
Issue 589 - Changed default machine image type for GKE

### DIFF
--- a/tb-gcp-tools/tb-auto-projects-deleter/cloud-function/main.py
+++ b/tb-gcp-tools/tb-auto-projects-deleter/cloud-function/main.py
@@ -29,6 +29,7 @@ def delete_tbase_deployments(event, context):
     for bootstrap_project in bootstrap_project_dicts:
         tb_folder = bootstrap_project['parent']['id']
         __delete_tbase_deployment(tb_folder)
+        
 
 
 def __delete_tbase_deployment(tb_folder):

--- a/tb-gcp-tr/kubernetes-cluster-creation/variables.tf
+++ b/tb-gcp-tr/kubernetes-cluster-creation/variables.tf
@@ -39,7 +39,7 @@ variable "cluster_pool_name" {
 
 variable "cluster_machine_type" {
   type    = string
-  default = "n1-standard-4"
+  default = "n2-standard-4"
 }
 
 variable "cluster_enable_private_nodes" {

--- a/tb-gcp-tr/kubernetes-cluster-creation/variables.tf
+++ b/tb-gcp-tr/kubernetes-cluster-creation/variables.tf
@@ -39,7 +39,7 @@ variable "cluster_pool_name" {
 
 variable "cluster_machine_type" {
   type    = string
-  default = "n2-standard-4"
+  default = "e2-standard-4"
 }
 
 variable "cluster_enable_private_nodes" {


### PR DESCRIPTION
## PR Type  
What kind of change does this PR introduce?  
 
Changes the default machine image type for the GKE cluster from n1-standard-4 to e2-standard-4 to avoid STOCKOUT error when deploying in the EU a/b zones under the demo org.
Please check the boxes that applies to this PR.  
  
- [x] Bugfix  
- [ ] Feature  
- [ ] Code style update (formatting, local variables)  
- [ ] Refactoring (no functional changes, no api changes)  
- [ ] Build related changes  
- [ ] CI related changes  
- [ ] Documentation content changes  
- [ ] TranquilityBase application / infrastructure changes  
- [ ] Other... Please describe:  


## Purpose 
Describe the problem or feature with a **link** to the issues.    
Also please describe which sections of the code do what and for what reason.  
  
## Reviewers  
 - **Reviewer A** please review this part.  
 - **Review B** please review this part.  
  
  ## Checklist  
 - [ x] This PR is linked to one or more issues.  
 - [ x] This PR has been tested (attach evidence if possible).  
 - 
![image](https://user-images.githubusercontent.com/64899361/105158001-69079200-5b05-11eb-87a7-058ad89a9f6b.png)

 - [ ] This PR has passed style guidelines.  
