### PR TITLE
#656 rolled back jenkins from v0.0.19 to 0.0.14

### DIFF
--- a/tb-gcp-tr/shared-dac/jenkins-master.yaml
+++ b/tb-gcp-tr/shared-dac/jenkins-master.yaml
@@ -70,7 +70,7 @@ spec:
     spec:
       containers:
         - name: jenkins-master
-          image: gcr.io/tranquility-base-images/tb-jenkins:v0.0.19
+          image: gcr.io/tranquility-base-images/tb-jenkins:v0.0.14
           args: ["--prefix=/jenkins-service"]
           securityContext:
             privileged: true


### PR DESCRIPTION
## PR Type  
Rolling back jenkins version after A/B testing in lower environments 
  
- [x] Bugfix  
- [ ] Feature  
- [ ] Code style update (formatting, local variables)  
- [ ] Refactoring (no functional changes, no api changes)  
- [ ] Build related changes  
- [ ] CI related changes  
- [ ] Documentation content changes  
- [ ] TranquilityBase application / infrastructure changes  
- [ ] Other... Please describe:  


## Purpose 
Jenkins 0.0.19 has breaking changes preventing activator deployment 
  